### PR TITLE
docs: actualizar documentación de Lenguaje Quetzal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
-        "@astrojs/starlight": "^0.34.4",
-        "astro": "^5.10.1",
-        "typescript": "^5.6.3"
+        "@astrojs/starlight": "^0.36.0",
+        "astro": "^5.13.11",
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=18.20.8"
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.34.4.tgz",
-      "integrity": "sha512-NfQ6S2OaDG8aaiE+evVxSMpgqMkXPLa/yCpzG340EX2pRzFxPeTSvpei3Uz9KouevXRCctjHSItKjuZP+2syrQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.36.0.tgz",
+      "integrity": "sha512-aVJVBfvFuE2avsMDhmRzn6I5GjDhUwIQFlu3qH9a1C0fNsPYDw2asxHQODAD7EfGiKGvvHCJgHb+9jbJ8lCfNQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
@@ -363,9 +363,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -373,9 +373,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
       "cpu": [
         "ppc64"
       ],
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
       "cpu": [
         "arm"
       ],
@@ -405,9 +405,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
       "cpu": [
         "arm64"
       ],
@@ -421,9 +421,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
       "cpu": [
         "x64"
       ],
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
       "cpu": [
         "arm64"
       ],
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
       "cpu": [
         "x64"
       ],
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
       "cpu": [
         "arm64"
       ],
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
       "cpu": [
         "x64"
       ],
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
       "cpu": [
         "arm"
       ],
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
       "cpu": [
         "arm64"
       ],
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
       "cpu": [
         "ia32"
       ],
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
       "cpu": [
         "loong64"
       ],
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
       "cpu": [
         "mips64el"
       ],
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
       "cpu": [
         "ppc64"
       ],
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
       "cpu": [
         "riscv64"
       ],
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
       "cpu": [
         "s390x"
       ],
@@ -629,9 +629,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
       "cpu": [
         "x64"
       ],
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
       "cpu": [
         "arm64"
       ],
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
       "cpu": [
         "arm64"
       ],
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
       "cpu": [
         "x64"
       ],
@@ -708,10 +708,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
       "cpu": [
         "x64"
       ],
@@ -725,9 +741,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
       "cpu": [
         "arm64"
       ],
@@ -741,9 +757,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
       "cpu": [
         "ia32"
       ],
@@ -757,9 +773,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
       "cpu": [
         "x64"
       ],
@@ -817,10 +833,20 @@
         "@expressive-code/core": "^0.41.2"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
+      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
       "cpu": [
         "arm64"
       ],
@@ -836,13 +862,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
+      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
       "cpu": [
         "x64"
       ],
@@ -858,13 +884,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
       "cpu": [
         "arm64"
       ],
@@ -878,9 +904,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
       "cpu": [
         "x64"
       ],
@@ -894,9 +920,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
+      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
       "cpu": [
         "arm"
       ],
@@ -910,9 +936,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
+      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
       "cpu": [
         "arm64"
       ],
@@ -925,10 +951,26 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
+      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
+      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
       "cpu": [
         "s390x"
       ],
@@ -942,9 +984,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
+      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
       "cpu": [
         "x64"
       ],
@@ -958,9 +1000,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
+      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
       "cpu": [
         "arm64"
       ],
@@ -974,9 +1016,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
+      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
       "cpu": [
         "x64"
       ],
@@ -990,9 +1032,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
+      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
       "cpu": [
         "arm"
       ],
@@ -1008,13 +1050,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
+      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
       "cpu": [
         "arm64"
       ],
@@ -1030,13 +1072,35 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
+      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
+      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
       "cpu": [
         "s390x"
       ],
@@ -1052,13 +1116,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
+      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
       "cpu": [
         "x64"
       ],
@@ -1074,13 +1138,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
+      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
       "cpu": [
         "arm64"
       ],
@@ -1096,13 +1160,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
+      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
       "cpu": [
         "x64"
       ],
@@ -1118,20 +1182,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
+      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.5.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1140,10 +1204,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
+      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
+      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
       "cpu": [
         "ia32"
       ],
@@ -1160,9 +1243,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
+      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
       "cpu": [
         "x64"
       ],
@@ -1179,9 +1262,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@mdx-js/mdx": {
@@ -1621,60 +1704,60 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-yilc0S9HvTPyahHpcum8eonYrQtmGTU0lbtwxhA6jHv4Bm1cAdlPFRCJX4AHebkCm75aKTjjRAW+DezqD1b/cg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0",
+        "@shikijs/types": "3.13.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.7.0.tgz",
-      "integrity": "sha512-0t17s03Cbv+ZcUvv+y33GtX75WBLQELgNdVghnsdhTgU3hVcWcMsoP6Lb0nDTl95ZJfbP1mVMO0p3byVh3uuzA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.13.0.tgz",
+      "integrity": "sha512-Ty7xv32XCp8u0eQt8rItpMs6rU9Ki6LJ1dQOW3V/56PKDcpvfHPnYFbsx5FFUP2Yim34m/UkazidamMNVR4vKg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0",
+        "@shikijs/types": "3.13.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
-      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.13.0.tgz",
+      "integrity": "sha512-O42rBGr4UDSlhT2ZFMxqM7QzIU+IcpoTMzb3W7AlziI1ZF7R8eS2M0yt5Ry35nnnTX/LTLXFPUjRFCIW+Operg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0",
+        "@shikijs/types": "3.13.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
-      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.13.0.tgz",
+      "integrity": "sha512-672c3WAETDYHwrRP0yLy3W1QYB89Hbpj+pO4KhxK6FzIrDI2FoEXNiNCut6BQmEApYLfuYfpgOZaqbY+E9b8wQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.13.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
-      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.13.0.tgz",
+      "integrity": "sha512-Vxw1Nm1/Od8jyA7QuAenaV78BG2nSr3/gCGdBkLpfLscddCkzkL36Q5b67SrLLfvAJTOUzW39x4FHVCFriPVgg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.13.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.13.0.tgz",
+      "integrity": "sha512-oM9P+NCFri/mmQ8LoFGVfVyemm5Hi27330zuOBp0annwJdKH1kOLndw3zCtAVDehPLg9fKqoEx3Ht/wNZxolfw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -2071,71 +2154,72 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.10.1.tgz",
-      "integrity": "sha512-DJVmt+51jU1xmgmAHCDwuUgcG/5aVFSU+tcX694acAZqPVt8EMUAmUZcJDX36Z7/EztnPph9HR3pm72jS2EgHQ==",
+      "version": "5.13.11",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.13.11.tgz",
+      "integrity": "sha512-qKB+95GtyJSwVn5TDi31FTIcsohzA/nLhyATWn5VWqok1VLzZvm/1KHCk4tNElSrAQ5BisxUIMZWTh+B4X2JvQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
-        "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/markdown-remark": "6.3.2",
+        "@astrojs/internal-helpers": "0.7.3",
+        "@astrojs/markdown-remark": "6.3.7",
         "@astrojs/telemetry": "3.3.0",
         "@capsizecss/unpack": "^2.4.0",
         "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.1.4",
-        "acorn": "^8.14.1",
+        "@rollup/pluginutils": "^5.2.0",
+        "acorn": "^8.15.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
         "boxen": "8.0.1",
-        "ci-info": "^4.2.0",
+        "ci-info": "^4.3.0",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^1.0.1",
         "cookie": "^1.0.2",
         "cssesc": "^3.0.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.1.1",
+        "devalue": "^5.3.2",
         "diff": "^5.2.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "es-module-lexer": "^1.6.0",
+        "es-module-lexer": "^1.7.0",
         "esbuild": "^0.25.0",
         "estree-walker": "^3.0.3",
         "flattie": "^1.1.1",
         "fontace": "~0.3.0",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
-        "http-cache-semantics": "^4.1.1",
-        "import-meta-resolve": "^4.1.0",
+        "http-cache-semantics": "^4.2.0",
+        "import-meta-resolve": "^4.2.0",
         "js-yaml": "^4.1.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.30.17",
+        "magic-string": "^0.30.18",
         "magicast": "^0.3.5",
         "mrmime": "^2.0.1",
         "neotraverse": "^0.6.18",
         "p-limit": "^6.2.0",
         "p-queue": "^8.1.0",
-        "package-manager-detector": "^1.1.0",
-        "picomatch": "^4.0.2",
+        "package-manager-detector": "^1.3.0",
+        "picomatch": "^4.0.3",
         "prompts": "^2.4.2",
         "rehype": "^13.0.2",
-        "semver": "^7.7.1",
-        "shiki": "^3.2.1",
+        "semver": "^7.7.2",
+        "shiki": "^3.12.0",
+        "smol-toml": "^1.4.2",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.12",
-        "tsconfck": "^3.1.5",
+        "tinyglobby": "^0.2.14",
+        "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.5.0",
+        "unifont": "~0.5.2",
         "unist-util-visit": "^5.0.0",
-        "unstorage": "^1.15.0",
+        "unstorage": "^1.17.0",
         "vfile": "^6.0.3",
-        "vite": "^6.3.4",
-        "vitefu": "^1.0.6",
+        "vite": "^6.3.6",
+        "vitefu": "^1.1.1",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^21.1.1",
-        "yocto-spinner": "^0.2.1",
-        "zod": "^3.24.2",
-        "zod-to-json-schema": "^3.24.5",
+        "yocto-spinner": "^0.2.3",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6",
         "zod-to-ts": "^1.2.0"
       },
       "bin": {
@@ -2151,7 +2235,7 @@
         "url": "https://opencollective.com/astrodotbuild"
       },
       "optionalDependencies": {
-        "sharp": "^0.33.3"
+        "sharp": "^0.34.0"
       }
     },
     "node_modules/astro-expressive-code": {
@@ -2164,6 +2248,41 @@
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.3.tgz",
+      "integrity": "sha512-6Pl0bQEIChuW5wqN7jdKrzWfCscW2rG/Cz+fzt4PhSQX2ivBpnhXgFUCs0M3DCYvjYHnPVG2W36X5rmFjZ62sw==",
+      "license": "MIT"
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.7.tgz",
+      "integrity": "sha512-KXGdq6/BC18doBCYXp08alHlWChH0hdD2B1qv9wIyOHbvwI5K6I7FhSta8dq1hBQNdun8YkKPR013D/Hm8xd0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.7.3",
+        "@astrojs/prism": "3.3.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "import-meta-resolve": "^4.2.0",
+        "js-yaml": "^4.1.0",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "shiki": "^3.12.2",
+        "smol-toml": "^1.4.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/axobject-query": {
@@ -2395,9 +2514,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "funding": [
         {
           "type": "github",
@@ -2536,20 +2655,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2567,17 +2672,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2721,9 +2815,9 @@
       "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -2743,9 +2837,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
-      "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
+      "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -2877,9 +2971,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2889,31 +2983,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escalade": {
@@ -3100,10 +3195,13 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -3215,17 +3313,17 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.3.tgz",
-      "integrity": "sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
+      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
-        "crossws": "^0.3.4",
+        "crossws": "^0.3.5",
         "defu": "^6.1.4",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.0",
+        "node-mock-http": "^1.0.2",
         "radix3": "^1.1.2",
         "ufo": "^1.6.1",
         "uncrypto": "^0.1.3"
@@ -3662,9 +3760,9 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3709,13 +3807,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
@@ -3901,12 +3992,12 @@
       "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/magicast": {
@@ -5123,15 +5214,15 @@
       }
     },
     "node_modules/node-fetch-native": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-      "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
     },
     "node_modules/node-mock-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.1.tgz",
-      "integrity": "sha512-0gJJgENizp4ghds/Ywu2FCmcRsgBTmRQzYPZm61wy+Em2sBarSka0OhQS5huLBg6od1zkNpnWMCZloQDFVvOMQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
+      "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -5328,9 +5419,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5982,16 +6073,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
+      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.0",
+        "semver": "^7.7.2"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -6000,51 +6091,44 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.4",
+        "@img/sharp-darwin-x64": "0.34.4",
+        "@img/sharp-libvips-darwin-arm64": "1.2.3",
+        "@img/sharp-libvips-darwin-x64": "1.2.3",
+        "@img/sharp-libvips-linux-arm": "1.2.3",
+        "@img/sharp-libvips-linux-arm64": "1.2.3",
+        "@img/sharp-libvips-linux-ppc64": "1.2.3",
+        "@img/sharp-libvips-linux-s390x": "1.2.3",
+        "@img/sharp-libvips-linux-x64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
+        "@img/sharp-linux-arm": "0.34.4",
+        "@img/sharp-linux-arm64": "0.34.4",
+        "@img/sharp-linux-ppc64": "0.34.4",
+        "@img/sharp-linux-s390x": "0.34.4",
+        "@img/sharp-linux-x64": "0.34.4",
+        "@img/sharp-linuxmusl-arm64": "0.34.4",
+        "@img/sharp-linuxmusl-x64": "0.34.4",
+        "@img/sharp-wasm32": "0.34.4",
+        "@img/sharp-win32-arm64": "0.34.4",
+        "@img/sharp-win32-ia32": "0.34.4",
+        "@img/sharp-win32-x64": "0.34.4"
       }
     },
     "node_modules/shiki": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.7.0.tgz",
-      "integrity": "sha512-ZcI4UT9n6N2pDuM2n3Jbk0sR4Swzq43nLPgS/4h0E3B/NrFn2HKElrDtceSf8Zx/OWYOo7G1SAtBLypCp+YXqg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.13.0.tgz",
+      "integrity": "sha512-aZW4l8Og16CokuCLf8CF8kq+KK2yOygapU5m3+hoGw0Mdosc6fPitjM+ujYarppj5ZIKGyPDPP1vqmQhr+5/0g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.7.0",
-        "@shikijs/engine-javascript": "3.7.0",
-        "@shikijs/engine-oniguruma": "3.7.0",
-        "@shikijs/langs": "3.7.0",
-        "@shikijs/themes": "3.7.0",
-        "@shikijs/types": "3.7.0",
+        "@shikijs/core": "3.13.0",
+        "@shikijs/engine-javascript": "3.13.0",
+        "@shikijs/engine-oniguruma": "3.13.0",
+        "@shikijs/langs": "3.13.0",
+        "@shikijs/themes": "3.13.0",
+        "@shikijs/types": "3.13.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/sisteransi": {
@@ -6079,9 +6163,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.0.tgz",
-      "integrity": "sha512-IMxaDA/58wBvkvX77ykQ6e9r6fjs8xbxpz8bMCyVQ/fEFWbA5uJrnaVwDuhLrrANGdd7apRyTPDBvI893Bxu9g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -6201,13 +6285,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6299,9 +6383,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6531,17 +6615,17 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.16.0.tgz",
-      "integrity": "sha512-WQ37/H5A7LcRPWfYOrDa1Ys02xAbpPJq6q5GkO88FBXVSQzHd7+BjEwfRqyaSWCv9MbsJy058GWjjPjcJ16GGA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.1.tgz",
+      "integrity": "sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^4.0.3",
         "destr": "^2.0.5",
-        "h3": "^1.15.2",
+        "h3": "^1.15.4",
         "lru-cache": "^10.4.3",
-        "node-fetch-native": "^1.6.6",
+        "node-fetch-native": "^1.6.7",
         "ofetch": "^1.4.1",
         "ufo": "^1.6.1"
       },
@@ -6554,10 +6638,11 @@
         "@azure/storage-blob": "^12.26.0",
         "@capacitor/preferences": "^6.0.3 || ^7.0.0",
         "@deno/kv": ">=0.9.0",
-        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
         "@planetscale/database": "^1.19.0",
         "@upstash/redis": "^1.34.3",
         "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
         "@vercel/kv": "^1.0.1",
         "aws4fetch": "^1.0.20",
         "db0": ">=0.2.1",
@@ -6600,6 +6685,9 @@
           "optional": true
         },
         "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
           "optional": true
         },
         "@vercel/kv": {
@@ -6671,9 +6759,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -6745,13 +6833,14 @@
       }
     },
     "node_modules/vitefu": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.7.tgz",
-      "integrity": "sha512-eRWXLBbJjW3X5z5P5IHcSm2yYbYRPb2kQuc+oqsbAl99WB5kVsPbiiox+cymo8twTzifA6itvhr2CmjnaZZp0Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
+      "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
-        "tests/projects/*"
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
       ],
       "peerDependencies": {
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
@@ -7293,9 +7382,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
-    "@astrojs/starlight": "^0.34.4",
-    "astro": "^5.10.1",
-    "typescript": "^5.6.3"
+    "@astrojs/starlight": "^0.36.0",
+    "astro": "^5.13.11",
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=18.20.8"

--- a/src/content/docs/control/bucles.mdx
+++ b/src/content/docs/control/bucles.mdx
@@ -1,16 +1,78 @@
 ---
 title: Bucles
-description: Estructuras de repetición en el Lenguaje Quetzal
+description: Estructuras repetitivas disponibles en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## `mientras`
 
-Esta sección necesita ser completada con información sobre los bucles en el Lenguaje Quetzal.
+Ejecuta el bloque mientras la condición sea verdadera.
 
-## Contenido pendiente:
-- Bucle for
-- Bucle while
-- Bucle do-while
-- Bucles anidados
-- Control de bucles (break, continue)
-- Ejemplos de uso
+```qz
+entero var i = 0
+mientras (i < 3) {
+    consola.mostrar(t"Iteración {i}")
+    i++
+}
+```
+
+## `hacer ... mientras`
+
+Evalúa la condición al final del bloque, garantizando al menos una ejecución.
+
+```qz
+entero var numero = 0
+hacer {
+    consola.mostrar("Este mensaje se imprime al menos una vez")
+    numero++
+} mientras (numero < 2)
+```
+
+## `para`
+
+Existe en dos variantes:
+
+1. **Clásica** con inicialización, condición e incremento.
+
+    ```qz
+    para (entero var j = 0; j < 5; j++) {
+        consola.mostrar(j.texto())
+    }
+    ```
+
+2. **Iteración sobre colecciones** usando `en` o `cada`.
+
+    ```qz
+    lista<entero> numeros = [10, 20, 30]
+    para (entero var valor en numeros) {
+        consola.mostrar(valor.texto())
+    }
+
+    para (entero var valor cada numeros) {
+        consola.mostrar(valor.texto())
+    }
+    ```
+
+Ambas formas crean un nuevo ámbito para las variables del bucle.
+
+## Control del ciclo
+
+- `romper`: finaliza el bucle actual.
+- `continuar`: omite la iteración en curso y evalúa la siguiente.
+
+```qz
+para (entero var k = 0; k < 5; k++) {
+    si (k == 2) {
+        continuar
+    }
+    si (k == 4) {
+        romper
+    }
+    consola.mostrar(k.texto())
+}
+```
+
+## Recomendaciones
+
+- Evita bucles infinitos verificando que la condición cambie en cada iteración.
+- Usa métodos de listas (`sumar`, `promedio`, `buscar`) cuando simplifiquen el código en lugar de iteraciones manuales.
+- Si necesitas acumular resultados, inicializa las variables fuera del bucle y documenta la intención con comentarios breves.

--- a/src/content/docs/control/condicionales.mdx
+++ b/src/content/docs/control/condicionales.mdx
@@ -1,16 +1,69 @@
 ---
 title: Condicionales
-description: Estructuras condicionales en el Lenguaje Quetzal
+description: Uso de las estructuras condicionales en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## `si`
 
-Esta sección necesita ser completada con información sobre las estructuras condicionales en el Lenguaje Quetzal.
+Evalúa una condición y ejecuta el bloque asociado cuando es `verdadero`.
 
-## Contenido pendiente:
-- Sentencia if
-- Sentencia if-else
-- Sentencia else if
-- Operador ternario
-- Switch/match
-- Ejemplos de uso
+```qz
+entero edad = 20
+
+si (edad >= 18) {
+    consola.mostrar("Es mayor de edad")
+}
+```
+
+## `sino`
+
+Opcionalmente se añade un bloque `sino` para manejar el caso contrario.
+
+```qz
+si (edad >= 18) {
+    consola.mostrar("Es mayor de edad")
+} sino {
+    consola.mostrar("Es menor de edad")
+}
+```
+
+## `sino si`
+
+Permite encadenar condiciones adicionales.
+
+```qz
+si (edad > 60) {
+    consola.mostrar("Tercera edad")
+} sino si (edad >= 18) {
+    consola.mostrar("Mayor de edad")
+} sino {
+    consola.mostrar("Menor de edad")
+}
+```
+
+## Condicionales en expresiones
+
+Puedes usar el operador ternario para condicionales simples.
+
+```qz
+texto estado = edad >= 18 ? "Mayor" : "Menor"
+```
+
+## Comparaciones estrictas
+
+- Usa `==` para comparar valores.
+- Para JSON y listas se compara la estructura completa.
+- Evita comparar diferentes tipos sin conversión previa; de lo contrario se generará un error.
+
+```qz
+jsn usuario = { nombre: "Ana", activo: verdadero }
+si (usuario.activo == verdadero) {
+    consola.mostrar("Usuario activo")
+}
+```
+
+## Buenas prácticas
+
+- Agrupa condiciones complejas con paréntesis para mejorar la lectura.
+- Aprovecha métodos como `contiene_clave` o `longitud()` antes de evaluar condiciones sobre JSON o listas.
+- Extrae condiciones a funciones descriptivas cuando se repiten en varios lugares.

--- a/src/content/docs/control/flujo.mdx
+++ b/src/content/docs/control/flujo.mdx
@@ -1,16 +1,81 @@
 ---
-title: Control de Flujo
-description: Instrucciones de control de flujo en Quetzal
+title: Control de flujo
+description: Herramientas para modificar el flujo de ejecución en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## `retornar`
 
-Esta sección necesita ser completada con información sobre el control de flujo en el Lenguaje Quetzal.
+Finaliza una función y devuelve un valor. En funciones de tipo `vacio` se puede omitir.
 
-## Contenido pendiente:
-- Break y continue
-- Return
-- Exit/quit
-- Goto (si está disponible)
-- Manejo de excepciones básico
-- Ejemplos de uso
+```qz
+texto saludar(texto nombre) {
+    retornar t"Hola, {nombre}"
+}
+```
+
+Los constructores de objetos no permiten `retornar`; el valor implícito siempre es `vacio`.
+
+## `romper`
+
+Sale inmediatamente del bucle actual (`para`, `mientras`, `hacer ... mientras` o iteraciones con `en`/`cada`).
+
+```qz
+entero var contador = 0
+mientras (contador < 10) {
+    si (contador == 5) {
+        romper
+    }
+    contador++
+}
+```
+
+## `continuar`
+
+Omite el resto del bloque actual y evalúa la siguiente iteración del bucle.
+
+```qz
+para (entero var i = 0; i < 5; i++) {
+    si (i % 2 == 0) {
+        continuar
+    }
+    consola.mostrar(i.texto())
+}
+```
+
+## `lanzar`
+
+Genera una excepción que puede ser capturada más arriba en la pila de llamadas.
+
+```qz
+número dividir(número a, número b) {
+    si (b == 0) {
+        lanzar "División por cero"
+    }
+    retornar a / b
+}
+```
+
+## `intentar`, `capturar`, `finalmente`
+
+Manejan excepciones generadas dentro del bloque `intentar`. El parámetro de `capturar` debe usar el tipo `excepcion`.
+
+```qz
+intentar {
+    número resultado = dividir(10, 0)
+    consola.mostrar(resultado.texto())
+} capturar (excepcion error) {
+    consola.mostrar_error(error.mensaje)
+} finalmente {
+    consola.mostrar("Operación finalizada")
+}
+```
+
+## `esperar` (reservado)
+
+La palabra clave `esperar` está reservada para la futura ejecución de funciones asincrónicas. En v0.0.12 aún no está habilitada.
+
+## Flujo de salida del programa
+
+El intérprete no incluye instrucciones explícitas como `exit` o `quit`. Para finalizar basta con permitir que el programa alcance el final del archivo o usar `retornar` en el punto de entrada si tu aplicación está organizada dentro de una función principal.
+
+Estas herramientas, combinadas con condicionales y bucles, permiten controlar el comportamiento de tus programas.

--- a/src/content/docs/datos/conversion-tipos.mdx
+++ b/src/content/docs/datos/conversion-tipos.mdx
@@ -1,16 +1,58 @@
 ---
-title: Conversión de Tipos
-description: Conversión entre diferentes tipos de datos en Quetzal
+title: Conversión de tipos
+description: Métodos disponibles para convertir valores en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+La conversión de tipos se realiza mediante métodos definidos sobre cada valor. Si la conversión no es posible se lanza una excepción.
 
-Esta sección necesita ser completada con información sobre la conversión de tipos en el Lenguaje Quetzal.
+## De texto a otros tipos
 
-## Contenido pendiente:
-- Conversión implícita
-- Conversión explícita
-- Funciones de conversión
-- Validación de tipos
-- Manejo de errores en conversiones
-- Ejemplos de uso
+```qz
+entero numero = "123".entero()
+número decimal = "123.45".número()
+log booleano = "verdadero".log()
+jsn objeto = "{\"nombre\":\"Ana\"}".jsn()
+lista<entero> desde_texto = "1,2,3".lista()
+```
+
+Los métodos aceptan valores en español (`"verdadero"`, `"falso"`) y números en formato decimal.
+
+## De números a texto y otros formatos
+
+```qz
+texto como_texto = 42.texto()
+texto numero_decimal = 3.14.texto()
+```
+
+## De listas y JSON
+
+```qz
+lista<entero> numeros = [1, 2, 3]
+texto lista_a_texto = numeros.texto()
+texto lista_a_json = numeros.json()
+
+jsn persona = {
+    nombre: "Ana",
+    edad: 30
+}
+texto json_a_texto = persona.texto()
+texto json_formateado = persona.texto_formateado()
+```
+
+## Manejo de errores
+
+Cuando una conversión falla, se genera una excepción que puedes capturar.
+
+```qz
+intentar {
+    entero valor = "abc".entero()
+} capturar (excepcion error) {
+    consola.mostrar_error(error.mensaje)
+}
+```
+
+## Reglas generales
+
+- Las conversiones no modifican el valor original; devuelven una nueva instancia.
+- Para listas tipadas, los elementos deben ser compatibles con el tipo de destino.
+- Al convertir a `lista` desde texto se espera una cadena separada por comas; ajusta el formato según tus necesidades.

--- a/src/content/docs/datos/json.mdx
+++ b/src/content/docs/datos/json.mdx
@@ -1,16 +1,78 @@
 ---
-title: Objetos JSON
-description: Manejo de objetos JSON en el Lenguaje Quetzal
+title: JSON
+description: Manipulación de valores `jsn` en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Los valores `jsn` representan objetos JSON con soporte nativo para propiedades anidadas, listas y métodos utilitarios.
 
-Esta sección necesita ser completada con información sobre los objetos JSON en el Lenguaje Quetzal.
+## Declaración
 
-## Contenido pendiente:
-- Sintaxis de objetos JSON
-- Acceso a propiedades
-- Métodos de objetos
-- Serialización y deserialización
-- Objetos anidados
-- Ejemplos de uso
+```qz
+jsn var persona = {
+    nombre: "Ana",
+    datos_personales: {
+        fecha_nacimiento: "1998-05-15",
+        dpi: "1234567890101"
+    },
+    direcciones: [
+        { tipo: "casa", direccion: "Ciudad" },
+        { tipo: "trabajo", direccion: "Antigua" }
+    ],
+    telefonos: ["555-1234", "555-5678"],
+    activo: verdadero
+}
+```
+
+## Acceso a propiedades
+
+- Por punto: `persona.nombre`
+- Por índice o clave con corchetes: `persona["datos_personales"].dpi`
+- Índices en listas anidadas: `persona.direcciones[0].direccion`
+
+## Métodos frecuentes
+
+| Método | Descripción |
+|--------|-------------|
+| `contiene_clave(clave)` | Verifica si la propiedad existe. |
+| `claves()` | Devuelve una lista de las claves de primer nivel. |
+| `valores()` | Devuelve una lista de los valores. |
+| `establecer(clave, valor)` | Asigna o crea una propiedad. |
+| `eliminar(clave)` | Elimina una propiedad y devuelve el valor eliminado. |
+| `fusionar(otro_json)` | Combina propiedades (las existentes se sobrescriben). |
+| `texto()` | Serializa sin formato. |
+| `texto_formateado()` | Serializa con indentación. |
+
+Los métodos mutadores requieren que el `jsn` se declare con `var`.
+
+## Ejemplo de uso
+
+```qz
+jsn var persona = {
+    nombre: "Ana",
+    activo: verdadero
+}
+
+persona.establecer("apellido", "Gómez")
+log tiene_dpi = persona.contiene_clave("dpi")
+
+si (no tiene_dpi) {
+    persona.establecer("dpi", "0000000000000")
+}
+
+texto como_texto = persona.texto_formateado()
+consola.mostrar(como_texto)
+```
+
+## Conversión desde texto
+
+```qz
+jsn configuracion = "{\"puerto\":8080,\"debug\":true}".jsn()
+```
+
+Si la cadena no es JSON válido se lanza una excepción, por lo que conviene envolver la operación en `intentar` y `capturar`.
+
+## Buenas prácticas
+
+- Declara los `jsn` que deban modificarse con la palabra `var`.
+- Usa `claves()` y `valores()` para iterar sobre propiedades en combinación con bucles.
+- Restringe el acceso a rutas del sistema de archivos mediante `quetzal.json` cuando importes módulos que manipulan JSON proveniente de archivos externos.

--- a/src/content/docs/datos/listas.mdx
+++ b/src/content/docs/datos/listas.mdx
@@ -1,16 +1,87 @@
 ---
 title: Listas
-description: Manejo de listas en el Lenguaje Quetzal
+description: Operaciones con listas en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Las listas representan colecciones ordenadas de valores. Pueden declararse con tipo específico (`lista<entero>`) o sin tipo (`lista`).
 
-Esta sección necesita ser completada con información sobre las listas en el Lenguaje Quetzal.
+## Declaración
 
-## Contenido pendiente:
-- Declaración de listas
-- Acceso a elementos
-- Métodos de listas
-- Iteración sobre listas
-- Listas multidimensionales
-- Ejemplos de uso
+```qz
+lista<texto> nombres = ["Ana", "Carlos", "María"]
+lista mixta = [1, "dos", verdadero]
+lista<entero> vacia = []
+```
+
+Las listas son inmutables a menos que se indiquen como variables con `var`.
+
+```qz
+lista<entero> var numeros = [3, 1, 4]
+numeros.agregar(2)
+```
+
+## Acceso a elementos
+
+- Índices positivos comienzan en 0.
+- Índices negativos acceden desde el final (`-1` es el último elemento).
+
+```qz
+texto segundo = nombres[1]
+texto ultimo = nombres[-1]
+```
+
+## Métodos principales
+
+| Método | Descripción |
+|--------|-------------|
+| `longitud()` | Número de elementos. |
+| `esta_vacia()` | Devuelve `verdadero` si la lista no tiene elementos. |
+| `agregar(valor)` | Inserta al final (lista mutable). |
+| `insertar(indice, valor)` | Inserta en una posición específica. |
+| `remover(valor)` | Elimina la primera coincidencia. |
+| `quitar_en(indice)` | Elimina y devuelve el elemento de la posición indicada. |
+| `limpiar()` | Vacía la lista. |
+| `contiene(valor)` | Verifica la presencia de un valor. |
+| `buscar(valor)` / `buscar_ultimo(valor)` | Devuelve la posición de la coincidencia. |
+| `contar(valor)` | Número de veces que aparece un valor. |
+| `ordenar()` / `ordenar_descendente()` | Ordena elementos comparables. |
+| `ordenado()` | Devuelve una copia ordenada. |
+| `invertir()` | Invierte el orden de la lista mutable. |
+| `primero()` / `ultimo()` | Obtiene el primer o último elemento. |
+| `tomar(n)` | Crea una sublista con los primeros `n` elementos. |
+| `saltar(n)` | Omite los primeros `n` elementos. |
+| `sublista(inicio, fin)` | Extrae un rango (sin incluir `fin`). |
+| `sumar()` / `promedio()` / `maximo()` / `minimo()` | Operaciones numéricas. |
+| `unir(delimitador)` | Concatena elementos como texto. |
+| `concatenar(otra_lista)` | Devuelve una nueva lista con los elementos combinados. |
+| `extender(otra_lista)` | Añade todos los elementos de otra lista (mutable). |
+| `texto()` | Representación textual. |
+| `json()` | Convierte la lista a JSON. |
+
+## Ejemplos prácticos
+
+```qz
+lista<entero> var numeros = [3, 1, 4]
+numeros.ordenar()                     // [1, 3, 4]
+
+lista<texto> palabras = ["Hola", "Quetzal"]
+texto frase = palabras.unir(" ")      // "Hola Quetzal"
+
+lista rango = rango(1, 5)              // [1, 2, 3, 4, 5]
+```
+
+## Validaciones
+
+- Para usar métodos mutadores (`agregar`, `ordenar`, etc.) la lista debe declararse con `var`.
+- Los métodos de ordenación requieren elementos comparables; mezclar tipos incompatibles genera un error.
+- Cuando un índice no existe, el intérprete lanza una excepción que puede manejarse con `intentar` y `capturar`.
+
+```qz
+intentar {
+    texto elemento = nombres[10]
+} capturar (excepcion error) {
+    consola.mostrar_advertencia(error.mensaje)
+}
+```
+
+Las listas son fundamentales para procesar colecciones de datos y trabajar con módulos nativos como `Matemática`.

--- a/src/content/docs/ejemplos/basicos.mdx
+++ b/src/content/docs/ejemplos/basicos.mdx
@@ -1,16 +1,62 @@
 ---
-title: Ejemplos Básicos
-description: Ejemplos básicos de código en el Lenguaje Quetzal
+title: Ejemplos básicos
+description: Fragmentos sencillos para familiarizarse con Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Hola mundo
 
-Esta sección necesita ser completada con ejemplos básicos de código en el Lenguaje Quetzal.
+```qz
+consola.mostrar_exito("Hola desde Lenguaje Quetzal")
+```
 
-## Contenido pendiente:
-- Hola mundo
-- Variables y tipos
-- Operaciones matemáticas
-- Condicionales simples
-- Bucles básicos
-- Funciones simples
+## Variables y tipos
+
+```qz
+entero edad = 25
+número salario = 1250.50
+texto nombre = "Ana"
+log activo = verdadero
+lista<texto> habilidades = ["Quetzal", "Rust", "JSON"]
+```
+
+## Operaciones matemáticas
+
+```qz
+número resultado = 10.5 + 5.25
+número diferencia = resultado - 3
+número producto = resultado * 2
+número division = resultado / 3
+consola.mostrar(t"Resultado final: {division}")
+```
+
+## Condicionales simples
+
+```qz
+entero edad = 20
+
+si (edad >= 18) {
+    consola.mostrar("Es mayor de edad")
+} sino {
+    consola.mostrar("Es menor de edad")
+}
+```
+
+## Bucles básicos
+
+```qz
+para (entero var i = 0; i < 3; i++) {
+    consola.mostrar(t"Iteración {i}")
+}
+```
+
+## Funciones
+
+```qz
+texto saludar(texto nombre) {
+    retornar "Hola " + nombre
+}
+
+consola.mostrar(saludar("María"))
+```
+
+Estos ejemplos están basados en la carpeta `ejemplos` incluida con el intérprete y sirven como punto de partida para explorar el lenguaje.

--- a/src/content/docs/ejemplos/mejores-practicas.mdx
+++ b/src/content/docs/ejemplos/mejores-practicas.mdx
@@ -1,16 +1,41 @@
 ---
-title: Mejores Prácticas
-description: Mejores prácticas de programación en el Lenguaje Quetzal
+title: Mejores prácticas
+description: Recomendaciones para escribir código mantenible en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Estilo general
 
-Esta sección necesita ser completada con las mejores prácticas de programación en el Lenguaje Quetzal.
+- Usa nombres en español y descriptivos (`obtener_usuario`, `calcular_promedio`).
+- Prefiere `camelCase` para funciones y `snake_case` para variables largas; mantén la consistencia en todo el archivo.
+- Añade comentarios solo cuando aclaren la intención del código.
 
-## Contenido pendiente:
-- Convenciones de código
-- Patrones de diseño
-- Optimización de rendimiento
-- Seguridad
-- Testing
-- Documentación de código
+## Organización de archivos
+
+- Agrupa funciones relacionadas en módulos y expórtalas explícitamente.
+- Coloca los módulos en carpetas permitidas por `quetzal.json` y documenta los permisos requeridos.
+- Mantén un archivo principal breve que importe la funcionalidad necesaria.
+
+## Tipos y mutabilidad
+
+- Declara siempre el tipo de las variables y evita la mutabilidad a menos que sea imprescindible.
+- Para listas y JSON mutables utiliza `var` y valida los datos antes de modificarlos.
+- Usa métodos de conversión (`.entero()`, `.texto()`) en lugar de concatenar o parsear manualmente.
+
+## Manejo de errores
+
+- Valida entradas con condicionales antes de ejecutar operaciones críticas.
+- Utiliza `intentar`/`capturar` en bloques pequeños para localizar fácilmente la causa del error.
+- Proporciona mensajes de excepción concretos con instrucciones de solución.
+
+## Uso de objetos
+
+- Define atributos privados para mantener invariantes internos y expón métodos públicos bien documentados.
+- Emplea miembros `libre` para utilidades que no dependen del estado del objeto.
+- Evita herencias complejas; prefiere composición y módulos reutilizables.
+
+## Pruebas manuales
+
+- Reproduce los ejemplos oficiales en una carpeta `pruebas-ia` para validar que el intérprete se ejecute correctamente.
+- Ejecuta los programas con el binario compilado (`target/release/quetzal archivo.qz`) después de cada cambio importante.
+
+Seguir estas prácticas ayuda a aprovechar las características del lenguaje y facilita la colaboración con otros desarrolladores.

--- a/src/content/docs/ejemplos/proyectos.mdx
+++ b/src/content/docs/ejemplos/proyectos.mdx
@@ -1,16 +1,35 @@
 ---
-title: Proyectos Completos
-description: Proyectos completos de ejemplo en el Lenguaje Quetzal
+title: Ideas de proyectos
+description: Propuestas para practicar con Lenguaje Quetzal usando la versión v0.0.12.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## 1. Calculadora de presupuesto
 
-Esta sección necesita ser completada con proyectos completos de ejemplo en el Lenguaje Quetzal.
+- Usa listas para almacenar gastos y `Matemática.promedio` o `Matemática.suma_total` para obtener métricas.
+- Solicita datos mediante `consola.pedir` y valida entradas con condicionales.
+- Exporta las funciones principales en un módulo `finanzas.qz` y reutilízalas en el archivo principal.
 
-## Contenido pendiente:
-- Calculadora
-- Juego simple
-- Aplicación CRUD
-- API REST básica
-- Procesador de archivos
-- Aplicación con interfaz
+## 2. Gestor de tareas sencillo
+
+- Define un objeto `Tarea` con atributos `texto` y `log` para indicar si está completada.
+- Implementa métodos en `Tarea` para marcar y mostrar el estado usando `ambiente`.
+- Crea una lista mutable de tareas y proporciona funciones para agregar, listar y filtrar tareas completadas.
+
+## 3. Analizador de texto
+
+- Aplica los métodos de `texto` para dividir frases, contar palabras y normalizar mayúsculas.
+- Usa `metodos_listas.qz` como referencia para ordenar resultados o eliminar duplicados.
+- Implementa manejo de excepciones al convertir valores y muestra resultados con `consola.mostrar_informacion`.
+
+## 4. Reporte estadístico
+
+- Importa `Matemática` y calcula promedio, máximo y mínimo de una lista de mediciones.
+- Genera un JSON con los resultados y conviértelo a texto formateado para imprimirlo.
+- Exporta el reporte en un módulo para reutilizarlo en diferentes conjuntos de datos.
+
+## 5. Biblioteca de utilidades
+
+- Agrupa funciones de uso frecuente (validaciones, transformaciones de texto, generadores de listas) en uno o varios módulos.
+- Documenta cada función con comentarios y crea ejemplos en la carpeta `pruebas-ia` para verificar su comportamiento con el intérprete.
+
+Estas ideas pueden ampliarse combinando módulos, objetos y listas. Inspírate en los archivos de la carpeta `ejemplos` para partir de código probado.

--- a/src/content/docs/errores/excepciones.mdx
+++ b/src/content/docs/errores/excepciones.mdx
@@ -1,16 +1,55 @@
 ---
 title: Excepciones
-description: Sistema de excepciones en el Lenguaje Quetzal
+description: Manejo de errores en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Las excepciones permiten reaccionar ante situaciones inesperadas en tiempo de ejecución.
 
-Esta sección necesita ser completada con información sobre el sistema de excepciones en el Lenguaje Quetzal.
+## Lanzar excepciones
 
-## Contenido pendiente:
-- Tipos de excepciones
-- Lanzar excepciones
-- Excepciones personalizadas
-- Jerarquía de excepciones
-- Propagación de errores
-- Ejemplos de uso
+Usa `lanzar` con un texto descriptivo o un objeto personalizado.
+
+```qz
+vacio validar_correo(texto correo) {
+    si (!correo.contiene("@")) {
+        lanzar "El correo no es válido"
+    }
+}
+```
+
+## Capturar excepciones
+
+El bloque `intentar` encapsula el código a vigilar. `capturar` recibe una variable de tipo `excepcion` con información sobre el error y la pila de llamadas.
+
+```qz
+intentar {
+    validar_correo("usuario")
+} capturar (excepcion error) {
+    consola.mostrar_error(error.mensaje)
+    consola.mostrar(t"Pila: {error.llamadas.texto()}")
+}
+```
+
+## Bloque `finalmente`
+
+Se ejecuta siempre, ocurra o no una excepción. Es útil para liberar recursos o mostrar mensajes finales.
+
+```qz
+intentar {
+    // Código que puede fallar
+} capturar (excepcion error) {
+    consola.mostrar_error(error.mensaje)
+} finalmente {
+    consola.mostrar("Fin del proceso")
+}
+```
+
+## Propagación
+
+Si no existe un bloque `capturar`, la excepción se propaga hasta el punto de entrada y el intérprete muestra un mensaje con la línea y sugerencias.
+
+## Buenas prácticas
+
+- Usa mensajes claros que indiquen cómo corregir el problema.
+- Evita capturar excepciones genéricas sin actuar sobre ellas.
+- Valida argumentos y estados antes de realizar operaciones que puedan fallar (divisiones, acceso a índices, conversiones de tipos).

--- a/src/content/docs/errores/try-catch.mdx
+++ b/src/content/docs/errores/try-catch.mdx
@@ -1,16 +1,58 @@
 ---
-title: Manejo de Errores con Try-Catch-Finally
-description: Manejo de errores con try-catch-finally en Quetzal
+title: Bloques intentar/capturar
+description: Uso detallado de `intentar`, `capturar` y `finalmente` en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Sintaxis general
 
-Esta sección necesita ser completada con información sobre try-catch-finally en el Lenguaje Quetzal.
+```qz
+intentar {
+    // Código que podría lanzar una excepción
+} capturar (excepcion error) {
+    // Manejo de la excepción
+} finalmente {
+    // Código opcional que siempre se ejecuta
+}
+```
 
-## Contenido pendiente:
-- Sintaxis de try-catch
-- Múltiples catch
-- Bloque finally
-- Captura de excepciones específicas
-- Re-lanzar excepciones
-- Ejemplos de uso
+- El bloque `capturar` es obligatorio cuando utilizas `intentar`.
+- `finalmente` es opcional, pero recomendado cuando debes liberar recursos.
+
+## Acceder a la información de la excepción
+
+El objeto `excepcion` incluye:
+
+- `mensaje`: texto descriptivo.
+- `linea`: número de línea donde ocurrió el error.
+- `llamadas`: lista con la pila de llamadas.
+
+```qz
+intentar {
+    número resultado = dividir(10, 0)
+} capturar (excepcion error) {
+    consola.mostrar_error(t"Mensaje: {error.mensaje}")
+    consola.mostrar(t"Línea: {error.linea}")
+    consola.mostrar(t"Pila: {error.llamadas.texto()}")
+}
+```
+
+## Múltiples excepciones
+
+Actualmente no existe clasificación jerárquica de excepciones. Todas las excepciones capturadas exponen al menos el mensaje y una lista de llamadas (actualmente vacía). Si necesitas categorizar errores, agrega información al texto del mensaje.
+
+## Re-lanzar excepciones
+
+Puedes propagar una excepción después de procesarla.
+
+```qz
+} capturar (excepcion error) {
+    consola.mostrar_advertencia("Reintentando")
+    lanzar error.mensaje
+}
+```
+
+## Consejos
+
+- Limita el tamaño del bloque `intentar` para identificar con precisión dónde ocurre el problema.
+- Registra información adicional antes de lanzar excepciones críticas.
+- Aprovecha el bloque `finalmente` para cerrar conexiones o limpiar estructuras temporales.

--- a/src/content/docs/funciones/asincronas.mdx
+++ b/src/content/docs/funciones/asincronas.mdx
@@ -1,16 +1,31 @@
 ---
-title: Funciones Asíncronas
-description: Programación asíncrona con funciones en Quetzal
+title: Funciones asincrónicas
+description: Estado actual del soporte asincrónico en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+La gramática de Lenguaje Quetzal incluye las palabras reservadas `asincrono` y `esperar` para preparar el soporte de funciones asincrónicas. Sin embargo, en la versión v0.0.12 estas características aún no están implementadas en el intérprete.
 
-Esta sección necesita ser completada con información sobre las funciones asíncronas en el Lenguaje Quetzal.
+## Sintaxis reservada
 
-## Contenido pendiente:
-- Declaración de funciones async
-- Uso de await
-- Promesas y futures
-- Manejo de errores asíncronos
-- Concurrencia
-- Ejemplos de uso
+```qz
+asincrono texto obtener_datos() {
+    // Implementación pendiente
+}
+
+texto resultado = esperar obtener_datos()
+```
+
+El código anterior no puede ejecutarse actualmente; el intérprete mostrará un error indicando que la funcionalidad no está disponible.
+
+## Hoja de ruta
+
+- Las funciones marcadas con `asincrono` podrán ejecutar operaciones que devuelvan promesas o tareas diferidas.
+- `esperar` permitirá pausar la función en curso hasta que finalice la tarea asincrónica.
+- El sistema respetará las mismas reglas de tipos y manejo de errores que las funciones sincrónicas.
+
+## Recomendaciones temporales
+
+- Implementa operaciones dependientes de E/S como funciones sincrónicas y usa módulos nativos (por ejemplo, `quetzal/matemática`) mientras el soporte asincrónico se completa.
+- Sigue las actualizaciones de la hoja de ruta para conocer la disponibilidad de esta característica.
+
+Cuando la funcionalidad se publique, esta sección incluirá ejemplos prácticos y patrones recomendados.

--- a/src/content/docs/funciones/definicion.mdx
+++ b/src/content/docs/funciones/definicion.mdx
@@ -1,16 +1,77 @@
 ---
-title: Definición de Funciones
-description: Cómo definir funciones en el Lenguaje Quetzal
+title: Definición de funciones
+description: Sintaxis y características de las funciones en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Declaración básica
 
-Esta sección necesita ser completada con información sobre la definición de funciones en el Lenguaje Quetzal.
+```qz
+texto saludar(texto nombre) {
+    retornar "Hola " + nombre
+}
+```
 
-## Contenido pendiente:
-- Sintaxis básica de funciones
-- Tipos de retorno
-- Funciones sin retorno
-- Funciones con múltiples parámetros
-- Funciones recursivas
-- Ejemplos de uso
+- Las funciones requieren tipo de retorno explícito (`vacio` cuando no devuelven valor).
+- El cuerpo se define entre llaves.
+- `retornar` finaliza la ejecución y devuelve el valor indicado.
+
+## Funciones sin retorno
+
+```qz
+vacio mostrar_mensaje(texto mensaje) {
+    consola.mostrar(mensaje)
+}
+```
+
+## Funciones mutando parámetros
+
+Los parámetros son inmutables por defecto. Para permitir modificación se usa la palabra `var` dentro de la firma.
+
+```qz
+texto agregar_sufijo(texto var base) {
+    base += " agregado"
+    retornar base
+}
+```
+
+## Funciones recursivas
+
+```qz
+entero factorial(entero n) {
+    si (n == 0) {
+        retornar 1
+    }
+    retornar n * factorial(n - 1)
+}
+```
+
+## Retornar objetos
+
+Las funciones pueden devolver instancias de objetos o listas.
+
+```qz
+objeto Usuario {
+    privado:
+        texto nombre
+        entero edad
+    publico:
+        Usuario(texto nombre, entero edad) {
+            ambiente.nombre = nombre
+            ambiente.edad = edad
+        }
+}
+
+Usuario crear_usuario(texto nombre, entero edad) {
+    retornar nuevo Usuario(nombre, edad)
+}
+```
+
+## Sobrecarga y nombres
+
+Actualmente Quetzal no admite sobrecarga de funciones; cada nombre debe ser único en el mismo ámbito. Puedes agrupar comportamientos relacionados en módulos u objetos.
+
+## Buenas prácticas
+
+- Usa nombres descriptivos en español siguiendo `camelCase` o `snake_case`.
+- Valida parámetros al inicio de la función y usa `lanzar` para notificar errores.
+- Mantén funciones cortas; extrae lógica en funciones auxiliares cuando sea necesario.

--- a/src/content/docs/funciones/parametros.mdx
+++ b/src/content/docs/funciones/parametros.mdx
@@ -1,16 +1,86 @@
 ---
-title: Parámetros y Argumentos
-description: Manejo de parámetros y argumentos en funciones de Quetzal
+title: Parámetros
+description: Cómo definir y utilizar parámetros en las funciones de Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Tipos explícitos
 
-Esta sección necesita ser completada con información sobre parámetros y argumentos en el Lenguaje Quetzal.
+Cada parámetro declara su tipo antes del nombre.
 
-## Contenido pendiente:
-- Parámetros posicionales
-- Parámetros con nombre
-- Parámetros por defecto
-- Parámetros variables
-- Paso por valor vs referencia
-- Ejemplos de uso
+```qz
+número sumar(número a, número b) {
+    retornar a + b
+}
+```
+
+## Parámetros modificables
+
+Usa `var` para permitir que el parámetro sea modificado dentro de la función. El cambio no afecta al argumento original porque Quetzal evalúa los argumentos por valor.
+
+```qz
+texto formatear(texto var mensaje) {
+    mensaje = mensaje.recortar()
+    mensaje = mensaje.titulo()
+    retornar mensaje
+}
+```
+
+## Listas y JSON como parámetros
+
+Puedes recibir listas tipadas, listas genéricas o valores `jsn`.
+
+```qz
+número promedio_lista(lista<número> valores) {
+    retornar valores.promedio()
+}
+
+texto obtener_nombre(jsn datos) {
+    retornar datos.nombre
+}
+```
+
+## Parámetros de objeto
+
+Para utilizar objetos definidos con `objeto`, declara el tipo correspondiente.
+
+```qz
+objeto Usuario {
+    publico:
+        Usuario(texto nombre) {
+            ambiente.nombre = nombre
+        }
+
+        texto saludo() {
+            retornar t"Hola {ambiente.nombre}"
+        }
+}
+
+texto presentar(Usuario usuario) {
+    retornar usuario.saludo()
+}
+```
+
+## Número variable de argumentos
+
+La versión v0.0.12 no incluye argumentos opcionales ni listas de parámetros variables. Para casos similares, acepta una lista y procesa los elementos manualmente.
+
+```qz
+número sumar_lista(lista<número> valores) {
+    retornar valores.sumar()
+}
+```
+
+## Validación de parámetros
+
+Aplica validaciones al inicio de la función y lanza excepciones cuando no se cumplan los requisitos.
+
+```qz
+número dividir(número a, número b) {
+    si (b == 0) {
+        lanzar "No es posible dividir entre cero"
+    }
+    retornar a / b
+}
+```
+
+Documenta el significado de cada parámetro mediante comentarios o nombres autoexplicativos para mantener el código legible.

--- a/src/content/docs/fundamentos/comentarios.mdx
+++ b/src/content/docs/fundamentos/comentarios.mdx
@@ -1,15 +1,40 @@
 ---
 title: Comentarios
-description: Sintaxis y uso de comentarios en Quetzal
+description: Formas de documentar código en Lenguaje Quetzal y recomendaciones de uso.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Lenguaje Quetzal admite dos estilos de comentarios.
 
-Esta sección necesita ser completada con información sobre los comentarios en el Lenguaje Quetzal.
+## Comentarios de una línea
 
-## Contenido pendiente:
-- Comentarios de línea simple
-- Comentarios de múltiples líneas
-- Comentarios de documentación
-- Buenas prácticas
-- Ejemplos de uso
+Empiezan con `//` y abarcan hasta el final de la línea.
+
+```qz
+// Inicia el programa
+consola.mostrar("Hola")
+```
+
+## Comentarios de varias líneas
+
+Se delimitan con `/*` y `*/`. El contenido puede abarcar múltiples líneas.
+
+```qz
+/*
+ Documentación del módulo de usuarios.
+ Incluye constructores y funciones auxiliares.
+*/
+objeto Usuario { ... }
+```
+
+### Comentarios anidados
+
+Los comentarios anidados no están soportados. Evita patrones como `/* ... /* ... */ ... */` porque el intérprete los considera un error de sintaxis.
+
+## Buenas prácticas
+
+- Describe el propósito de bloques complejos en lugar de repetir el código.
+- Mantén los comentarios sincronizados con el comportamiento real del programa.
+- En objetos y módulos, documenta la intención de los miembros `privado` y `publico` para facilitar el mantenimiento.
+- Usa comentarios para indicar requisitos de permisos definidos en `quetzal.json` cuando tu módulo dependa del sistema de archivos.
+
+Los comentarios se eliminan durante la interpretación y no afectan el rendimiento del programa.

--- a/src/content/docs/fundamentos/operadores.mdx
+++ b/src/content/docs/fundamentos/operadores.mdx
@@ -1,16 +1,99 @@
 ---
 title: Operadores
-description: Operadores disponibles en el Lenguaje Quetzal
+description: Operadores disponibles en Lenguaje Quetzal y ejemplos prácticos de uso.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Aritméticos
 
-Esta sección necesita ser completada con información sobre los operadores en el Lenguaje Quetzal.
+| Operador | Descripción | Ejemplo |
+|----------|-------------|---------|
+| `+` | Suma dos valores numéricos o concatena texto. | `número total = a + b`
+| `-` | Resta el segundo operando del primero. | `entero diferencia = a - b`
+| `*` | Multiplicación. | `entero producto = a * b`
+| `/` | División. Para enteros la división es entera. | `entero cociente = a / b`
+| `%` | Residuo o módulo. | `entero residuo = a % b`
 
-## Contenido pendiente:
-- Operadores aritméticos
-- Operadores de comparación
-- Operadores lógicos
-- Operadores de asignación
-- Precedencia de operadores
-- Ejemplos de uso
+```qz
+entero suma = 5 + 3
+texto combinado = "Hola" + " Quetzal"
+```
+
+## Relacionales
+
+| Operador | Descripción |
+|----------|-------------|
+| `==` | Igualdad.
+| `!=` | Desigualdad.
+| `>`  | Mayor que.
+| `<`  | Menor que.
+| `>=` | Mayor o igual que.
+| `<=` | Menor o igual que.
+
+```qz
+log es_mayor = 10 > 5
+log es_igual = "texto" == "texto"
+```
+
+## Lógicos
+
+Quetzal admite tanto los operadores simbólicos (`&&`, `||`, `!`) como sus equivalentes en español (`y`, `o`, `no`).
+
+```qz
+log acceso = (usuario.autenticado y !usuario.bloqueado)
+log disponible = (stock > 0) o (pedido_en_camino == verdadero)
+log negado = no acceso
+```
+
+Los valores no booleanos se convierten automáticamente a `log` siguiendo las reglas del intérprete (por ejemplo, listas vacías son `falso`).
+
+## Asignación
+
+| Operador | Descripción |
+|----------|-------------|
+| `=` | Asignación simple.
+| `+=` | Suma y asigna.
+| `-=` | Resta y asigna.
+| `*=` | Multiplica y asigna.
+| `/=` | Divide y asigna.
+| `%=` | Calcula el residuo y asigna.
+
+```qz
+entero var acumulado = 0
+acumulado += 5
+acumulado -= 2
+```
+
+## Incremento y decremento
+
+Los operadores `++` y `--` están disponibles en forma postfija.
+
+```qz
+entero var contador = 0
+contador++
+contador--
+```
+
+## Operador ternario
+
+La forma `condicion ? valor_si_verdadero : valor_si_falso` está disponible para evaluaciones rápidas.
+
+```qz
+entero numero = -10
+entero absoluto = numero < 0 ? -numero : numero
+```
+
+## Operadores en listas y JSON
+
+Las listas y los valores `jsn` proveen métodos en lugar de operadores específicos. Por ejemplo, `lista.concatenar(otra_lista)` o `json.fusionar(otro_json)`. Consulta las secciones de tipos de datos para más información.
+
+## Precedencia
+
+- Llamadas a función y acceso a miembros.
+- Operadores unarios (`no`, `!`, `++`, `--`).
+- Multiplicación y división.
+- Suma y resta.
+- Comparaciones.
+- Operadores lógicos (`y`, `o`).
+- Asignaciones (`=`, `+=`, etc.).
+
+Usa paréntesis para aclarar la intención cuando combines varios operadores.

--- a/src/content/docs/fundamentos/sintaxis-basica.mdx
+++ b/src/content/docs/fundamentos/sintaxis-basica.mdx
@@ -1,323 +1,144 @@
 ---
-title: Sintaxis Básica
-description: Aprende la sintaxis fundamental del Lenguaje Quetzal, incluyendo variables, tipos de datos, operadores y estructuras básicas.
+title: Sintaxis básica
+description: Elementos esenciales de la sintaxis del Lenguaje Quetzal en su versión v0.0.12.
 ---
 
-El Lenguaje Quetzal es un lenguaje de programación interpretado con tipado fuerte, diseñado para ser expresivo y eficiente. Esta guía te enseñará los fundamentos de su sintaxis.
-
-## Características Generales
-
-- **Sin punto y coma**: Las instrucciones no requieren `;` al final
-- **Tipado fuerte**: Todos los valores tienen un tipo específico
-- **Inmutabilidad por defecto**: Las variables son constantes a menos que se indique lo contrario
-- **Sintaxis en español**: Palabras clave y conceptos en español
+Lenguaje Quetzal utiliza una sintaxis limpia sin punto y coma. Cada instrucción ocupa su propia línea o bloque y las palabras clave están en español.
 
 ## Comentarios
 
-Los comentarios te permiten documentar tu código sin afectar la ejecución.
-
 ```qz
-// Esto es un comentario de una sola línea
+// Comentario de una línea
 
 /*
- Esto es un comentario
- de múltiples líneas
- que puede ocupar varias líneas
+ Comentario de varias líneas
+ que puede incluir saltos
+ de línea.
 */
 ```
 
-## Tipos de Datos
+## Tipos primitivos
 
-### Tipos Básicos
-
-Quetzal incluye los tipos de datos fundamentales para la mayoría de aplicaciones:
+- `vacio`: ausencia de valor.
+- `entero`: números enteros con signo.
+- `número`: valores de punto flotante.
+- `texto`: cadenas Unicode.
+- `log`: valores lógicos (`verdadero` o `falso`).
 
 ```qz
-// Tipo vacío - para variables sin valor inicial
-vacio variable_sin_valor
-
-// Números enteros
-entero edad = 25
-entero temperatura = -10
-
-// Números decimales
-número precio = 199.99
-número pi = 3.14159
-
-// Cadenas de texto
-cadena nombre = "María García"
-cadena mensaje = "¡Hola, mundo!"
-
-// Valores booleanos
-bool es_activo = verdadero
-bool tiene_permisos = falso
+vacio sin_valor
+entero edad = 27
+número temperatura = 22.5
+texto mensaje = "Hola"
+log activo = verdadero
 ```
 
-### Listas
+## Listas
 
-Las listas pueden contener elementos del mismo tipo o tipos mixtos:
+Las listas se declaran con `lista` y pueden ser tipadas o no tipadas.
 
 ```qz
-// Lista tipada - todos los elementos del mismo tipo
-lista<entero> numeros = [1, 2, 3, 4, 5]
-lista<cadena> nombres = ["Ana", "Carlos", "Luis"]
-
-// Lista automática - el intérprete deduce el tipo
-lista valores = [10, 20, 30]
-
-// Lista mixta - diferentes tipos de datos
-lista datos_mixtos = [42, "texto", verdadero, 3.14]
-
-// Lista vacía
-lista<cadena> lista_vacia = []
+lista<entero> numeros = [1, 2, 3]
+lista valores = [1, "dos", verdadero]
+lista<texto> vacia = []
 ```
 
-### Objetos JSON
-
-Quetzal tiene soporte nativo para objetos JSON:
+Las listas mutables usan `var` y permiten métodos como `agregar`, `ordenar` o `sumar`.
 
 ```qz
-// Objeto JSON básico
-jsn persona = {
-    nombre: "Juan Pérez",
+lista<texto> var frutas = ["manzana", "naranja"]
+frutas.agregar("pera")
+consola.mostrar(frutas.texto())
+```
+
+## Valores JSON (`jsn`)
+
+```qz
+jsn var persona = {
+    nombre: "Ana",
     edad: 30,
     activo: verdadero,
-    salario: 2500.50
+    direcciones: [
+        { tipo: "casa", ciudad: "Guatemala" },
+        { tipo: "trabajo", ciudad: "Antigua" }
+    ]
 }
 
-// Objeto JSON anidado
-jsn empresa = {
-    nombre: "TechCorp",
-    empleados: {
-        total: 150,
-        departamentos: ["desarrollo", "ventas", "soporte"]
-    },
-    direccion: {
-        calle: "Av. Principal 123",
-        ciudad: "Guatemala"
-    }
-}
+texto ciudad = persona.direcciones[0].ciudad
+persona.establecer("activo", falso)
 ```
 
-## Variables Mutables
+## Variables y mutabilidad
 
-Por defecto, todas las variables son constantes. Para crear variables modificables, usa la palabra clave `mut`:
+Por defecto las variables son inmutables. Para permitir cambios se utiliza la palabra reservada `var` tras el tipo.
 
 ```qz
-// Variable constante (no se puede modificar)
-entero valor_fijo = 100
+entero contador = 10          // Inmutable
+entero var mutable = 5        // Mutable
+mutable += 1
 
-// Variable mutable (se puede modificar)
-entero mut contador = 0
-cadena mut mensaje_dinamico = "inicial"
-
-// Modificando variables mutables
-contador = contador + 1
-mensaje_dinamico = "modificado"
+lista<entero> var datos = [1, 2]
+datos.agregar(3)
 ```
 
-## Convenciones de Nombres
-
-Quetzal admite dos estilos de nomenclatura:
-
-```qz
-// Estilo camelCase
-entero miEdad = 25
-cadena nombreCompleto = "Ana López"
-bool estaActivo = verdadero
-
-// Estilo snake_case
-entero mi_edad = 25
-cadena nombre_completo = "Ana López"
-bool esta_activo = verdadero
-```
+Las listas y JSON declarados dentro de funciones pueden ser mutables sin `var` cuando el intérprete necesita modificar su contenido temporalmente, pero se recomienda declarar la intención de forma explícita.
 
 ## Operadores
 
-### Operadores Aritméticos
+### Aritméticos
 
 ```qz
-entero a = 10
+entero a = 7
 entero b = 3
 
-entero suma = a + b        // 13
-entero resta = a - b       // 7
-entero multiplicacion = a * b  // 30
-entero division = a / b    // 3
-entero modulo = a % b      // 1
+entero suma = a + b
+entero resta = a - b
+entero producto = a * b
+entero cociente = a / b
+entero residuo = a % b
+entero incremento = a++      // Operador postfijo
+entero decremento = b--
 ```
 
-### Operadores de Comparación
+### Comparación y lógica
 
 ```qz
-entero x = 10
-entero y = 20
+log igual = a == b
+log distinto = a != b
+log mayor = a > b
+log menor_o_igual = a <= b
 
-bool igual = x == y        // falso
-bool diferente = x != y    // verdadero
-bool mayor = x > y         // falso
-bool menor = x < y         // verdadero
-bool mayor_igual = x >= y  // falso
-bool menor_igual = x <= y  // verdadero
+log conjuncion = (a > 5) y (b < 10)   // También se puede usar &&
+log disyuncion = (a > 5) o (b < 10)   // También se puede usar ||
+log negado = no conjuncion            // También se puede usar !
 ```
 
-### Operadores Lógicos
+### Operadores de asignación compuesta
 
 ```qz
-bool a = verdadero
-bool b = falso
-
-// Operador Y (AND)
-bool resultado_y = a && b    // falso
-bool resultado_y2 = a y b    // falso (sintaxis alternativa)
-
-// Operador O (OR)
-bool resultado_o = a || b    // verdadero
-bool resultado_o2 = a o b    // verdadero (sintaxis alternativa)
-
-// Operador NO (NOT)
-bool resultado_no = !a       // falso
+entero var total = 0
+total += 5
+total -= 2
+total *= 3
+total /= 2
 ```
 
-### Operadores de Asignación
+## Interpolación de texto
+
+Las cadenas interpoladas se declaran con el prefijo `t` y permiten incrustar expresiones dentro de llaves `{}`.
 
 ```qz
-entero mut valor = 10
-
-valor += 5    // valor = valor + 5 (15)
-valor -= 3    // valor = valor - 3 (12)
-valor *= 2    // valor = valor * 2 (24)
-valor /= 4    // valor = valor / 4 (6)
-valor %= 5    // valor = valor % 5 (1)
+texto nombre = "Lucía"
+consola.mostrar(t"Hola, {nombre}")
 ```
 
-### Operadores de Incremento y Decremento
+## Entrada y salida básica
+
+Los métodos de `consola` permiten enviar mensajes y solicitar datos.
 
 ```qz
-entero mut contador = 5
-
-contador++    // Incrementa en 1 (6)
-contador--    // Decrementa en 1 (5)
+texto usuario = consola.pedir("Nombre:")
+consola.mostrar_exito(t"Bienvenido {usuario}")
 ```
 
-### Operador Ternario
-
-```qz
-entero edad = 20
-cadena categoria = edad >= 18 ? "adulto" : "menor"
-
-entero nota = 85
-cadena resultado = nota >= 70 ? "aprobado" : "reprobado"
-```
-
-## Concatenación de Cadenas
-
-```qz
-cadena nombre = "María"
-cadena apellido = "González"
-
-// Concatenación simple
-cadena nombre_completo = nombre + " " + apellido
-
-// Concatenación con números
-entero edad = 25
-cadena presentacion = "Me llamo " + nombre + " y tengo " + edad.cadena() + " años"
-
-// Concatenación con asignación
-cadena mut mensaje = "Hola"
-mensaje += " mundo"  // "Hola mundo"
-```
-
-## Conversión de Tipos
-
-Quetzal proporciona métodos para convertir entre diferentes tipos de datos:
-
-```qz
-// Convertir cadenas a números
-cadena texto_numero = "123"
-entero numero_entero = texto_numero.entero()
-número numero_decimal = "456.78".numero()
-
-// Convertir números a cadenas
-entero valor = 789
-cadena valor_texto = valor.cadena()
-
-// Convertir booleanos
-bool estado = verdadero
-cadena estado_texto = estado.cadena()
-
-// Convertir JSON
-cadena json_texto = '{"nombre": "Juan", "edad": 30}'
-jsn objeto = json_texto.jsn()
-```
-
-## Funciones de Consola
-
-Para mostrar información en pantalla:
-
-```qz
-// Mensaje normal
-imprimir("Hola, mundo!")
-
-// Mensajes con colores y estilos
-imprimir_exito("Operación completada correctamente")
-imprimir_error("Ha ocurrido un error")
-imprimir_advertencia("Cuidado con esta operación")
-imprimir_informacion("Información importante")
-```
-
-## Ejemplo Completo
-
-Aquí tienes un ejemplo que combina varios elementos de la sintaxis básica:
-
-```qz
-// Variables básicas
-cadena nombre = "Ana García"
-entero edad = 28
-número salario = 3500.50
-bool tiene_experiencia = verdadero
-
-// Lista de habilidades
-lista<cadena> habilidades = ["Python", "JavaScript", "Rust"]
-
-// Información del empleado como JSON
-jsn empleado = {
-    nombre: nombre,
-    edad: edad,
-    salario: salario,
-    departamento: "Desarrollo",
-    habilidades: habilidades,
-    activo: tiene_experiencia
-}
-
-// Operaciones y lógica
-cadena categoria = edad >= 25 ? "senior" : "junior"
-número salario_anual = salario * 12
-
-// Mostrar información
-imprimir_exito("=== INFORMACIÓN DEL EMPLEADO ===")
-imprimir("Nombre: " + nombre)
-imprimir("Categoría: " + categoria)
-imprimir("Salario anual: " + salario_anual.cadena())
-imprimir("Datos completos: " + empleado.cadena())
-```
-
-## Palabras Reservadas
-
-Es importante conocer las palabras que no puedes usar como nombres de variables:
-
-```
-vacio, entero, número, cadena, bool, verdadero, falso, lista, jsn,
-mut, tipo, publico, privado, libre, fn, retornar, objeto, nuevo, ambiente,
-asincrono, esperar, si, sino, mientras, para, hacer, romper, continuar,
-intentar, atrapar, finalmente, lanzar, excepción, importar, exportar,
-desde, como, y, o, en
-```
-
-## Próximos Pasos
-
-Ahora que conoces la sintaxis básica, puedes continuar con:
-
-- [Funciones](/fundamentos/funciones) - Cómo definir y usar funciones
-- [Estructuras de Control](/fundamentos/estructuras-control) - Condicionales y bucles
-- [Listas y Objetos](/fundamentos/listas-objetos) - Trabajo con estructuras de datos complejas
+Con estos elementos puedes leer el resto de los fundamentos y construir programas más complejos.

--- a/src/content/docs/fundamentos/tipos-datos.mdx
+++ b/src/content/docs/fundamentos/tipos-datos.mdx
@@ -1,14 +1,82 @@
 ---
 title: Tipos de datos
-description: Tipos de datos disponibles en el Lenguaje Quetzal
+description: Tipos disponibles en Lenguaje Quetzal, métodos de conversión y operaciones comunes.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Tipos primitivos
 
-Esta sección necesita ser completada con información sobre los tipos de datos disponibles en el Lenguaje Quetzal.
+| Tipo    | Descripción | Ejemplo |
+|---------|-------------|---------|
+| `vacio` | Ausencia de valor. Se utiliza para variables sin inicializar explícitamente o funciones sin retorno. | `vacio resultado`
+| `entero` | Números enteros con signo de 64 bits. | `entero edad = 32`
+| `número` | Valores decimales de doble precisión. | `número temperatura = 21.5`
+| `texto` | Cadenas Unicode. | `texto saludo = "Hola"`
+| `log` | Valores lógicos `verdadero` o `falso`. | `log habilitado = verdadero`
 
-## Contenido pendiente:
-- Tipos primitivos
-- Tipos complejos
-- Conversiones de tipos
-- Ejemplos de uso
+## Listas
+
+Las listas pueden ser tipadas o genéricas.
+
+```qz
+lista<texto> nombres = ["Ana", "Luis", "María"]
+lista valores = [1, "dos", verdadero]
+```
+
+Las listas mutables (`lista<tipo> var`) aceptan métodos como `agregar`, `insertar`, `quitar_en`, `ordenar` o `sumar`.
+
+```qz
+lista<entero> var numeros = [3, 1, 4]
+numeros.ordenar()
+consola.mostrar(numeros.texto())   // [1, 3, 4]
+```
+
+## JSON (`jsn`)
+
+Los objetos JSON son de primer nivel y admiten acceso por punto, por clave o mediante métodos auxiliares.
+
+```qz
+jsn var persona = {
+    nombre: "Ana",
+    datos: {
+        edad: 28,
+        ciudad: "Guatemala"
+    },
+    telefonos: ["555-1234", "555-5678"],
+    activo: verdadero
+}
+
+texto ciudad = persona.datos.ciudad
+persona.establecer("activo", falso)
+lista<texto> claves = persona.claves()
+```
+
+## Conversión de tipos
+
+Los valores ofrecen métodos de conversión explícitos. Si la operación no es posible, el intérprete genera un error de ejecución.
+
+```qz
+entero numero_entero = "123".entero()
+número numero_decimal = "123.45".número()
+log valor_logico = "verdadero".log()
+texto como_texto = numero_entero.texto()
+lista<entero> desde_texto = "1,2,3".lista()
+```
+
+Para convertir listas o JSON a texto legible:
+
+```qz
+lista<texto> palabras = ["Hola", "Quetzal"]
+texto representacion = palabras.texto()    // "[Hola, Quetzal]"
+texto json_pretty = persona.texto_formateado()
+```
+
+## Valores nulos
+
+El intérprete reconoce el literal `nulo`. Su uso es excepcional; se prefiere trabajar con estructuras que indiquen la ausencia de datos mediante listas vacías o JSON sin claves. Cuando se accede a una propiedad inexistente en un `jsn`, el resultado es `nulo`.
+
+```qz
+jsn datos = { nombre: "Ana" }
+log es_activo = datos.activo.logico()   // Lanza error si no se valida que la clave exista
+```
+
+Comprueba la presencia de claves usando `contiene_clave` antes de convertir valores.

--- a/src/content/docs/fundamentos/variables-constantes.mdx
+++ b/src/content/docs/fundamentos/variables-constantes.mdx
@@ -1,15 +1,81 @@
 ---
 title: Variables y constantes
-description: Declaración y uso de variables y constantes en Quetzal
+description: Declaración, mutabilidad y alcance de las variables en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Declaración básica
 
-Esta sección necesita ser completada con información sobre variables y constantes en el Lenguaje Quetzal.
+Cada variable requiere un tipo explícito seguido del nombre y, opcionalmente, un valor inicial.
 
-## Contenido pendiente:
-- Declaración de variables
-- Declaración de constantes
-- Ámbito de variables
-- Buenas prácticas
-- Ejemplos de uso
+```qz
+entero contador = 0
+texto saludo = "Hola"
+log activo = verdadero
+```
+
+Si no se proporciona un valor, Quetzal asigna uno por defecto acorde al tipo (`0` para `entero`, `0.0` para `número`, cadena vacía para `texto`, `falso` para `log`).
+
+## Mutabilidad
+
+Las variables son inmutables por defecto. Usa la palabra clave `var` para permitir reasignaciones o métodos que mutan el valor.
+
+```qz
+entero var total = 10
+total += 5
+
+lista<texto> var elementos = ["a", "b"]
+elementos.agregar("c")
+```
+
+## Nombres válidos
+
+- Inician con una letra o guion bajo y pueden contener números.
+- Admiten `camelCase` o `snake_case`.
+- No pueden coincidir con palabras reservadas como `si`, `lista`, `importar`, `nuevo`, `ambiente`, `verdadero`, `falso`, `nulo`, `y`, `o`, `no` y otras listadas en la sección de referencia.
+
+## Alcance
+
+- Las variables declaradas en el cuerpo principal tienen alcance global en el archivo.
+- Dentro de funciones u objetos, el alcance se limita al bloque correspondiente.
+- Cada bucle crea su propio ámbito, por lo que las variables definidas en el encabezado o dentro del bloque no son visibles fuera de él.
+
+```qz
+entero var acumulado = 0
+para (entero var numero en [1, 2, 3]) {
+    acumulado += numero
+}
+// numero ya no está disponible aquí
+```
+
+## Uso de `ambiente`
+
+En objetos, la palabra reservada `ambiente` permite acceder a los atributos y métodos internos.
+
+```qz
+objeto Contador {
+    entero var valor = 0
+
+    Contador(entero inicial) {
+        ambiente.valor = inicial
+    }
+
+    vacio incrementar() {
+        ambiente.valor++
+    }
+}
+```
+
+## Constantes simbólicas
+
+Actualmente no existe una palabra clave específica para constantes globales. Para simular una constante declara la variable sin `var` y evita reasignarla. Si necesitas compartirla en múltiples archivos, expórtala desde un módulo dedicado.
+
+```qz
+texto MENSAJE_BIENVENIDA = "Bienvenido"
+exportar { MENSAJE_BIENVENIDA }
+```
+
+## Buenas prácticas
+
+- Prefiere nombres descriptivos y consistentes.
+- Declara variables lo más cerca posible de su uso.
+- Evita usar mutabilidad salvo cuando sea estrictamente necesaria (por ejemplo, acumuladores o estructuras que cambian).

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lenguaje Quetzal
-description: Bienvenido a la documentación oficial del Lenguaje de Programación Quetzal v0.0.1
+description: Documentación oficial del Lenguaje de Programación Quetzal v0.0.12
 template: splash
 head:
   - tag: meta
@@ -11,7 +11,7 @@ head:
   - tag: meta
     attrs: {
       property: 'og:description',
-      content: 'Bienvenido a la documentación oficial del Lenguaje de Programación Quetzal v0.0.1'
+      content: 'Documentación del Lenguaje Quetzal v0.0.12 con guías, ejemplos y referencias en español'
     }
   - tag: meta
     attrs: {
@@ -41,7 +41,7 @@ head:
   - tag: meta
     attrs: {
       name: 'twitter:description',
-      content: 'Bienvenido a la documentación oficial del Lenguaje de Programación Quetzal v0.0.1'
+      content: 'Documentación del Lenguaje Quetzal v0.0.12 con guías, ejemplos y referencias en español'
     }
   - tag: meta
     attrs: {
@@ -49,17 +49,17 @@ head:
       content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
     }
 hero:
-  tagline: ¡Un lenguaje de programación moderno con sintaxis en español!
+  tagline: Un lenguaje de programación moderno con sintaxis en español
   image:
     alt: Logo de Lenguaje Quetzal
     light: ../../assets/logo_lenguaje_quetzal.png
     dark: ../../assets/logo_lenguaje_quetzal_blanc.png
   actions:
-    - text: Comenzar tutorial
+    - text: Comenzar recorrido
       link: /introduccion/bienvenido/
       icon: right-arrow
       variant: primary
-    - text: Ver en GitHub
+    - text: Repositorio en GitHub
       link: https://github.com/AntaresGT/lenguaje-quetzal
       icon: external
       variant: secondary
@@ -71,185 +71,73 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   <div class="floating-code">
     <pre class="code-snippet">
       <code class="language-qz">
-{`// Bienvenido a Lenguaje Quetzal
-cadena saludo = "¡Hola Guatemala!"
-número version = 0.0.1
-bool es_moderno = verdadero
+{`// Lenguaje Quetzal v0.0.12
+texto saludo = "Hola, Quetzal"
+log es_activo = verdadero
+lista<entero> valores = [1, 2, 3]
 
-imprimir_exito(saludo)
-imprimir("Versión: " + version.cadena())`}
+consola.mostrar_exito(saludo)
+consola.mostrar(t"Valores: {valores.texto()}")`}
       </code>
     </pre>
   </div>
 </div>
 
-## 🌟 ¿Por qué Lenguaje Quetzal?
+## Motivos para elegir Quetzal
 
 <div class="features-grid">
   <CardGrid>
-    <Card title="Sintaxis en Español" icon="document">
-      Programar en tu idioma nativo hace que el código sea más fácil de leer, entender y mantener. ¡Perfecto para la comunidad guatemalteca e hispanohablante!
+    <Card title="Sintaxis en español" icon="document">
+      Todas las palabras clave, tipos y mensajes del intérprete están en español, lo que facilita el aprendizaje y la lectura del código.
     </Card>
-    <Card title="Alto Rendimiento" icon="rocket">
-      Implementado en Rust para garantizar velocidad extrema y seguridad en memoria, sin sacrificar la facilidad de uso.
+    <Card title="Tipado fuerte" icon="setting">
+      El intérprete valida los tipos en tiempo de análisis y en ejecución. Las conversiones explícitas usan métodos como `.entero()` o `.texto()` cuando son seguras.
     </Card>
-    <Card title="Tipado Fuerte" icon="setting">
-      Sistema de tipos robusto que previene errores comunes en tiempo de compilación, haciendo tu código más confiable.
+    <Card title="Listas y JSON nativos" icon="open-book">
+      Las estructuras `lista` y `jsn` son de primera clase, con métodos integrados para acceder, convertir y manipular datos anidados.
     </Card>
-    <Card title="JSON Nativo" icon="open-book">
-      Soporte directo para estructuras JSON sin conversiones complicadas. Ideal para desarrollo web y APIs modernas.
+    <Card title="Orientado a objetos" icon="layers">
+      Define objetos con bloques `privado` y `publico`, constructores y miembros libres reutilizables sin instanciar.
     </Card>
-    <Card title="Objetivo y Funcional" icon="star">
-      No es un lenguaje para únicamente para aprender, sino para construir aplicaciones reales. Combinando paradigmas de programación orientada a objetos y funcional.
+    <Card title="Módulos con permisos" icon="shield">
+      Importa código desde archivos `.qz` y módulos nativos controlando el acceso mediante `quetzal.json`.
     </Card>
-    <Card title="Extendible" icon="github">
-      Diseñado para ser extensible y fácil de integrar con otras tecnologías. Puedes crear tus propias bibliotecas y módulos.
+    <Card title="Implementación en Rust" icon="rocket">
+      El intérprete escrito en Rust ofrece ejecución rápida, manejo detallado de errores y herramientas como la extensión oficial para VS Code.
     </Card>
   </CardGrid>
 </div>
 
-## 🚀 Ejemplo
+## Ejemplo rápido
 
-<div class="live-example">
-  <div class="code-container">
-    
 ```qz
-// Programa completo en Lenguaje Quetzal
-imprimir_exito("=== BIENVENIDO A QUETZAL ===")
+// Archivo ejemplo.qz
+importar {
+    Matemática
+} desde "quetzal/matemática"
 
-// Variables tipadas en español
-cadena nombre = "María Gonzalez"
-entero edad = 28
-número salario = 15000.50
-bool programadora = verdadero
+texto var mensaje = "Bienvenido"
+lista<texto> tecnologias = ["Quetzal", "Rust", "JSON"]
 
-// Lista de tecnologías
-lista<cadena> tecnologias = [
-    "Quetzal", "Python", "JavaScript", "Rust"
-]
+número resultado = Matemática.sumar(2, 3)
+consola.mostrar_exito(mensaje + " a Lenguaje Quetzal")
+consola.mostrar(t"Resultado: {resultado}")
 
-// Objeto JSON nativo
-jsn perfil = {
-    nombre: nombre,
-    edad: edad,
-    salario: salario,
-    ubicacion: "Guatemala City",
-    tecnologias: tecnologias,
-    activa: programadora
+para (texto tecnologia en tecnologias) {
+    consola.mostrar(t"Tecnología: {tecnologia}")
 }
-
-// Función con tipos explícitos
-cadena crear_presentacion(cadena nombre_dev, entero experiencia) {
-    si (experiencia >= 5) {
-        retornar "Desarrolladora Senior: " + nombre_dev
-    } sino {
-        retornar "Desarrolladora Junior: " + nombre_dev
-    }
-}
-
-// Ejecución
-cadena presentacion = crear_presentacion(nombre, 6)
-imprimir_informacion(presentacion)
-imprimir("Perfil completo: " + perfil.cadena())
-
-// Bucle con sintaxis natural
-para (cadena tech en tecnologias) {
-    imprimir("🔧 Domina: " + tech)
-}
-
-imprimir_exito("¡Código ejecutado exitosamente!")
 ```
-    
-  </div>
-</div>
 
-## 🎯 Características Destacadas
+## Cómo está organizada la documentación
 
-<div class="highlights-section">
-  <CardGrid>
-    <Card title="🌱 Fácil de Aprender" icon="approve-check">
-      Sintaxis intuitiva diseñada para que cualquier persona pueda comenzar a programar sin barreras del idioma.
-      
-      **Perfecto para:**
-      - Estudiantes principiantes
-      - Programadores experimentados
-      - Educación en español
-    </Card>
-    
-    <Card title="🏗️ Desarrollo Moderno" icon="laptop">
-      Todas las características que esperas de un lenguaje contemporáneo, pero en español.
-      
-      **Incluye:**
-      - Programación orientada a objetos
-      - Funciones asíncronas
-      - Manejo de excepciones
-      - Sistema de módulos
-    </Card>
-    
-    <Card title="🔗 Interoperabilidad" icon="setting">
-      Diseñado para integrarse perfectamente con el ecosistema de desarrollo actual.
-      
-      **Compatible con:**
-      - APIs REST
-      - Bases de datos
-      - Servicios web
-      - Herramientas modernas
-    </Card>
-    
-    <Card title="🎨 Expresivo y Elegante" icon="star">
-      Código limpio y legible que expresa tus ideas de manera natural.
-      
-      **Beneficios:**
-      - Menos errores de sintaxis
-      - Código autodocumentado
-      - Fácil mantenimiento
-      - Mejor colaboración en equipos
-    </Card>
-  </CardGrid>
-</div>
+- **Introducción**: recorrido inicial, instalación y primer programa.
+- **Fundamentos**: sintaxis, tipos, variables, operadores y comentarios.
+- **Control de flujo**: condicionales, bucles y sentencias de control.
+- **Tipos de datos**: listas, JSON y conversiones.
+- **Funciones y objetos**: definición, parámetros, asincronía reservada y programación orientada a objetos.
+- **Entrada y salida**: operaciones de consola y lineamientos actuales sobre archivos.
+- **Módulos y errores**: importaciones, exportaciones y manejo de excepciones.
+- **Referencia**: palabras reservadas, gramática y funciones integradas.
+- **Ejemplos**: casos básicos, proyectos sugeridos y recomendaciones de estilo.
 
-## 🗺️ Comienza tu Viaje
-
-<div class="journey-section">
-  <CardGrid>
-    <Card title="📚 1. Aprende lo Básico" icon="document">
-      Domina los fundamentos del lenguaje con nuestra guía paso a paso.
-      
-      [Sintaxis Básica →](/fundamentos/sintaxis-basica/)
-    </Card>
-    
-    <Card title="⚙️ 2. Instala Quetzal" icon="setting">
-      Configura tu entorno de desarrollo en minutos.
-      
-      [Guía de Instalación →](/introduccion/instalacion/)
-    </Card>
-    
-    <Card title="🎮 3. Practica con Ejemplos" icon="laptop">
-      Explora proyectos reales y casos de uso prácticos.
-      
-      [Ejemplos Prácticos →](/ejemplos/basicos/)
-    </Card>
-    
-    <Card title="🤝 4. Únete a la Comunidad" icon="github">
-      Contribuye al desarrollo y conecta con otros desarrolladores.
-      
-      [Contribuir en GitHub →](https://github.com/AntaresGT/lenguaje-quetzal)
-    </Card>
-  </CardGrid>
-</div>
-
----
-
-<div class="cta-section">
-  <h2>🚀 ¿Listo para Programar en Español?</h2>
-  <p>Únete a la revolución de la programación en español y descubre lo poderoso que puede ser Lenguaje Quetzal.</p>
-  
-  <div class="cta-buttons">
-    <a href="/introduccion/instalacion/" class="cta-primary">
-      ⚡ Instalar Ahora
-    </a>
-    <a href="/introduccion/primer-programa/" class="cta-secondary">
-      📖 Tutorial Rápido
-    </a>
-  </div>
-</div>
+Cada sección utiliza fragmentos probados de la carpeta `ejemplos` de la versión v0.0.12 del intérprete para que puedas experimentar con confianza.

--- a/src/content/docs/introduccion/bienvenido.mdx
+++ b/src/content/docs/introduccion/bienvenido.mdx
@@ -1,154 +1,70 @@
 ---
 title: Bienvenido a Lenguaje Quetzal
-description: Introducción al lenguaje de programación Quetzal v0.0.1, un lenguaje interpretado moderno desarrollado en Rust con sintaxis en español.
+description: Introducción general al Lenguaje Quetzal v0.0.12, sus metas y características principales.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-**Lenguaje Quetzal** es un lenguaje de programación interpretado moderno, diseñado con sintaxis completamente en español para hacer la programación más accesible a la comunidad hispanohablante.
+**Lenguaje Quetzal** es un intérprete moderno escrito en Rust con sintaxis íntegramente en español. La versión v0.0.12 mantiene un enfoque en tipado fuerte, estructuras de datos de alto nivel y herramientas para el desarrollo diario como módulos reutilizables y una extensión oficial para VS Code.
 
-## ¿Qué es Lenguaje Quetzal?
-
-Quetzal es un lenguaje interpretado en tiempo de ejecución, implementado en **Rust** para garantizar alto rendimiento y seguridad. Su diseño se enfoca en:
-
-- **Sintaxis en español**: Todas las palabras clave están en español
-- **Tipado fuerte**: Previene errores comunes en tiempo de compilación
-- **Soporte nativo de JSON**: Interoperabilidad directa con estructuras JSON
-- **Rendimiento optimizado**: Implementado en Rust para máxima eficiencia
-
-## Características principales
+## Objetivos del proyecto
 
 <CardGrid>
-  <Card title="Sintaxis Natural" icon="document">
-    Palabras clave en español como `si`, `sino`, `mientras`, `para`, haciendo el código más legible para hispanohablantes.
+  <Card title="Accesible para hispanohablantes" icon="document">
+    Todas las palabras clave usan español: `si`, `sino`, `lista`, `consola`, `retornar`, entre otras. Esta decisión reduce la curva de aprendizaje para quienes piensan y trabajan en español.
   </Card>
-  
-  <Card title="Tipado Fuerte" icon="setting">
-    Sistema de tipos robusto que detecta errores en tiempo de compilación, con tipos como `entero`, `cadena`, `número`, `bool`.
+  <Card title="Productividad inmediata" icon="rocket">
+    El intérprete ofrece listas, JSON y objetos orientados a la creación de aplicaciones reales. Los métodos integrados permiten manipular datos sin dependencias adicionales.
   </Card>
-  
-  <Card title="JSON Nativo" icon="open-book">
-    Soporte directo para objetos JSON con el tipo `jsn`, sin necesidad de conversiones externas.
+  <Card title="Robustez" icon="shield">
+    El análisis léxico y sintáctico detecta errores de forma temprana. Los mensajes incluyen sugerencias y resaltan la línea con el problema para depurar con rapidez.
   </Card>
-  
-  <Card title="Alto Rendimiento" icon="rocket">
-    Implementado en Rust para garantizar velocidad y seguridad en la ejecución.
-  </Card>
-
-  <Card title="Objetivo y Funcional" icon="star">
-      No es un lenguaje para únicamente para aprender, sino para construir aplicaciones reales. Combinando paradigmas de programación orientada a objetos y funcional.
-  </Card>
-  <Card title="Extendible" icon="github">
-    Diseñado para ser extensible y fácil de integrar con otras tecnologías. Puedes crear tus propias bibliotecas y módulos.
+  <Card title="Extensibilidad" icon="layers">
+    Los módulos permiten organizar código en archivos separados y compartir definiciones mediante `exportar` e `importar`. Además, la versión incluye módulos nativos como `quetzal/matemática`.
   </Card>
 </CardGrid>
 
-## Tu primer programa
+## Qué incluye la versión v0.0.12
 
-Aquí tienes un ejemplo básico de código Quetzal:
+- Tipos primitivos (`entero`, `número`, `texto`, `log`, `vacio`), listas tipadas y no tipadas, y valores `jsn` con métodos de acceso avanzados.
+- Objetos con bloques `privado` y `publico`, constructores, atributos libres y soporte para miembros estáticos.
+- Importaciones y exportaciones entre archivos `.qz`, alias de símbolos y permisos controlados mediante `quetzal.json` para acceder al sistema de archivos.
+- Manejo de excepciones con bloques `intentar`, `capturar`, `finalmente` y lanzamiento explícito de errores mediante `lanzar`.
+- Consola con métodos para mensajes de éxito, advertencia, error, información y solicitudes de entrada o contraseñas.
+
+## Primer vistazo al lenguaje
 
 ```qz
-// Mi primer programa en Quetzal
-imprimir_exito("¡Hola, mundo desde Lenguaje Quetzal!")
+importar {
+    Matemática
+} desde "quetzal/matemática"
 
-// Variables con tipos
-entero edad = 25
-cadena nombre = "María García"
-bool esta_activo = verdadero
+objeto Usuario {
+    privado:
+        texto nombre
+        entero edad
+    publico:
+        Usuario(texto nombre, entero edad) {
+            ambiente.nombre = nombre
+            ambiente.edad = edad
+        }
 
-// Función simple
-cadena saludar(cadena nombre_usuario) {
-    retornar "¡Hola, " + nombre_usuario + "!"
+        texto saludo() {
+            retornar t"Hola, {ambiente.nombre}. Tienes {ambiente.edad} años."
+        }
 }
 
-// Llamada a función
-cadena saludo = saludar(nombre)
-imprimir(saludo)
+Usuario persona = nuevo Usuario("María", 29)
+número suma = Matemática.sumar(7, 3)
 
-// Condicional
-si (edad >= 18) {
-    imprimir("Es mayor de edad")
-} sino {
-    imprimir("Es menor de edad")
-}
-
-// Lista de datos
-lista<cadena> frutas = ["manzana", "banana", "naranja"]
-para (cadena fruta en frutas) {
-    imprimir("Fruta: " + fruta)
-}
-
-// Objeto JSON
-jsn persona = {
-    nombre: "Ana López",
-    edad: 30,
-    ciudad: "Guatemala",
-    activo: verdadero
-}
-
-imprimir("Persona: " + persona.cadena())
+consola.mostrar_exito(persona.saludo())
+consola.mostrar(t"Resultado de 7 + 3: {suma}")
 ```
 
-## ¿Por qué Quetzal?
+## Recursos disponibles
 
-### 1. **Accesibilidad lingüística**
-Quetzal elimina la barrera del idioma en la programación, permitiendo que los desarrolladores hispanohablantes trabajen con conceptos familiares en su idioma nativo.
+- **Repositorio principal** con el intérprete y la carpeta `ejemplos` utilizada en esta documentación: [github.com/AntaresGT/lenguaje-quetzal/tree/v0.0.12](https://github.com/AntaresGT/lenguaje-quetzal/tree/v0.0.12)
+- **Extensión oficial de VS Code** para resaltado y ejecución rápida de archivos `.qz`.
+- **Canal comunitario** en el repositorio para reportar problemas y proponer mejoras.
 
-### 2. **Diseño moderno**
-Incorpora características de lenguajes modernos como:
-- Inferencia de tipos
-- Programación asíncrona con `asincrono` y `esperar`
-- Manejo de errores con `intentar`, `atrapar`, `finalmente`
-- Sistema de módulos con `importar` y `exportar`
-
-### 3. **Comunidad hispanohablante**
-Diseñado específicamente para fomentar el crecimiento de la programación en la comunidad de habla hispana.
-
-## Próximos pasos
-
-<CardGrid>
-  <Card title="Instalación" icon="setting">
-    Aprende cómo instalar y configurar el intérprete de Quetzal en tu sistema.
-    
-    [Ver guía de instalación →](/introduccion/instalacion)
-  </Card>
-  
-  <Card title="Tu primer programa" icon="rocket">
-    Crea y ejecuta tu primer programa en Lenguaje Quetzal paso a paso.
-    
-    [Crear primer programa →](/introduccion/primer-programa)
-  </Card>
-  
-  <Card title="Fundamentos" icon="document">
-    Explora los conceptos básicos del lenguaje: tipos, variables y sintaxis.
-    
-    [Aprender fundamentos →](/fundamentos/sintaxis-basica)
-  </Card>
-  
-  <Card title="Ejemplos" icon="open-book">
-    Revisa ejemplos prácticos y proyectos de muestra para inspirarte.
-    
-    [Ver ejemplos →](/ejemplos/basicos)
-  </Card>
-</CardGrid>
-
-## Filosofía del proyecto
-
-> *"La programación no debería requerir que abandones tu idioma nativo. Quetzal trae la programación moderna al español, manteniendo la potencia y elegancia de los lenguajes contemporáneos."*
-
-No veas a Quetzal solo como un lenguaje de aprendizaje, sino como una herramienta poderosa para desarrollar aplicaciones modernas y eficientes, todo en idioma Español.
-
----
-
-## Hecho en Guatemala
-
-El nombre "Quetzal" rinde homenaje al ave nacional de Guatemala, simbolizando libertad y belleza.
-El lenguaje fue creado por un equipo muy pequeño de desarrolladores guatemaltecos apasionados por la tecnología sin fronteras.
-
-## Contribuciones
-Quetzal es un proyecto de código abierto. Puedes contribuir al desarrollo, reportar errores o sugerir mejoras en nuestro repositorio de GitHub:
-[Contribuir en GitHub](https://github.com/AntaresGT/lenguaje-quetzal/discussions)
-
----
-
-¿Listo para comenzar? Continúa con la [guía de instalación](/introduccion/instalacion) para configurar tu entorno de desarrollo.
+Con estos materiales puedes seguir el resto de la documentación y comenzar a construir aplicaciones con Lenguaje Quetzal.

--- a/src/content/docs/introduccion/hoja-de-ruta.mdx
+++ b/src/content/docs/introduccion/hoja-de-ruta.mdx
@@ -1,48 +1,32 @@
 ---
-title: Hoja de Ruta
-description: Descubre la hoja de ruta de Lenguaje Quetzal, desde sus inicios hasta el futuro. Aprende sobre su evolución, características clave y cómo puedes contribuir.
+title: Hoja de ruta
+description: Estado actual del Lenguaje Quetzal y próximos pasos planificados.
 ---
 
-## 🎯 Misión
-Crear un lenguaje de programación en español y que sea totalmente funcional para proposito general, no únicamente para enseñanza.
+## Estado actual (v0.0.12)
 
-## 🚀 Visión a corto plazo
-Que Lenguaje Quetzal se convierta en una herramienta capaz de ejecutarse en un servidor para responder peticiones y ejecutar código en tiempo real, facilitando el desarrollo de aplicaciones web y servicios backend.
+- Intérprete estable capaz de ejecutar archivos `.qz` desde la línea de comandos.
+- Soporte completo para listas, JSON, objetos y módulos con permisos configurables.
+- Manejo de errores con mensajes descriptivos y pila de llamadas disponible en las excepciones.
+- Módulos nativos distribuidos con el intérprete (`quetzal/matemática`) y extensión oficial para VS Code.
 
-## 🌱 Motivación
-La programación no tiene fronteras, pero sí puede tener raíces. Quetzal busca ofrecer a la comunidad hispanohablante con un lenguaje moderno, seguro, eficiente y totalmente en español, permitiendo a los desarrolladores hispanohablantes crear aplicaciones de manera más intuitiva y natural. Además de facilitar la enseñanza de conceptos de programación a quienes tienen el español como lengua materna.
+## Prioridades confirmadas
 
-## 🏭 Quetzal es para producción
-No veas Quetzal como un lenguaje de programación únicamente para aprender a programar, sino, como una herramienta poderosa que puede ser utilizada por desarrolladores experimentados para crear aplicaciones robustas y eficientes. Actualmente en su versión 0.0.1, Quetzal ya cuenta con un intérprete funcional y una extensión para Visual Studio Code que mejora la experiencia de desarrollo.
+1. **Ampliar módulos nativos**: nuevas utilidades de fecha y hora, manipulación de archivos y acceso a redes siguiendo el esquema de permisos de `quetzal.json`.
+2. **Funciones asincrónicas**: las palabras reservadas `asincrono` y `esperar` ya existen en la gramática y se documentan como características reservadas; la implementación de corrutinas está en progreso.
+3. **Herramientas de empaquetado**: comandos para crear proyectos desde plantillas y ejecutar pruebas automatizadas.
+4. **Documentación bilingüe**: la presente documentación se mantiene en español; una traducción oficial al inglés llegará después de consolidar la versión actual.
 
-## 🗺️ ¿En dónde se encuentra Quetzal?
+## Buenas prácticas mientras llegan nuevas versiones
 
-### v0.0.1 (Actual) ✅
-- [x] Intérprete básico en Rust
-- [x] Tipos de datos fundamentales
-- [x] Funciones definidas por el usuario
-- [x] Control de flujo (si/sino, bucles)
-- [x] Soporte JSON nativo
-- [x] Sistema de tipos fuerte
-- [x] Extensión VS Code
+- Consulta regularmente la carpeta `ejemplos` para conocer cambios recientes y patrones sugeridos.
+- Usa `quetzal.json` para restringir el acceso a directorios cuando compartas proyectos.
+- Mantén tu intérprete actualizado ejecutando `git pull` sobre la rama `v0.0.12` y reconstruyendo con `cargo build --release`.
 
-### v0.0.2 (Próximamente)
-- [ ] Sistema de módulos (`importar/exportar`)
-- [ ] Manejo de excepciones (`intentar/atrapar/finalmente`)
-- [ ] Herencia multiple
-- [ ] Funciones asíncronas completas
-- [ ] Operadores avanzados
-- [ ] REPL interactivo
+## Participa en el desarrollo
 
-### v0.1.0 (Futuro)
-- [ ] Librerías estándar
-- [ ] Gestión de paquetes
-- [ ] Debugger integrado
-- [ ] Facilidad para crear aplicaciones de servidor como API REST
-- [ ] Conexión a bases de datos
-- [ ] Herramientas de desarrollo
+- Reporta problemas y abre propuestas en [github.com/AntaresGT/lenguaje-quetzal/issues](https://github.com/AntaresGT/lenguaje-quetzal/issues).
+- Comparte módulos o plantillas en la comunidad para ayudar a validar nuevas características.
+- Contribuye a esta documentación proponiendo ejemplos adicionales o corrigiendo descripciones.
 
-### v0.2.0 (Futuro lejano)
-- [ ] Soporte con Floem para crear aplicaciones de escritorio y móviles (en duda XD)
-- [ ] Soporte para crear aplicaciones web con Quetzal
-- [ ] Computación gráfica avanzada con Quetzal
+La hoja de ruta se revisa en cada iteración del intérprete. Revisa esta sección con frecuencia para conocer las novedades.

--- a/src/content/docs/introduccion/instalacion.mdx
+++ b/src/content/docs/introduccion/instalacion.mdx
@@ -1,200 +1,88 @@
 ---
-title: Instalación de Lenguaje Quetzal
-description: Guía paso a paso para instalar el intérprete de Lenguaje Quetzal en Windows.
+title: Instalación
+description: Requisitos y pasos para compilar y ejecutar Lenguaje Quetzal v0.0.12.
 ---
 
-import { Card, CardGrid, Steps, Badge } from '@astrojs/starlight/components';
+## Prerrequisitos
 
-Esta guía te llevará paso a paso por el proceso de instalación del intérprete de Lenguaje Quetzal en Windows.
+Para compilar el intérprete desde el código fuente necesitas:
 
-<Badge text="Solo Windows" variant="note" />
+- **Rust** 1.70 o superior con `cargo` instalado mediante [rustup.rs](https://rustup.rs/).
+- **Git** para clonar el repositorio oficial.
+- **Node.js** 18.20.8 o superior únicamente si deseas contribuir con la documentación.
 
-## Requisitos del sistema
+Verifica las versiones con los siguientes comandos:
 
-<CardGrid>
-  <Card title="Sistema Operativo" icon="laptop">
-    - Windows 10 (64-bit) o superior
-    - Windows 11 (recomendado)
-  </Card>
-  
-  <Card title="Hardware Mínimo" icon="setting">
-    - RAM: 2 GB mínimo (4 GB recomendado)
-    - Almacenamiento: 100 MB libres
-    - Procesador: x64 compatible
-  </Card>
-</CardGrid>
-
-## Instalación paso a paso
-
-<Steps>
-
-1. **Descargar el ejecutable**
-   
-   Ve a la página de releases en GitHub y descarga la versión más reciente:
-    - [Releases de Lenguaje Quetzal](https://github.com/AntaresGT/lenguaje-quetzal/releases)
-    - Busca el archivo llamado `quetzal.exe` en la sección **Assets** de la release más reciente.
-
-2. **Crear directorio de instalación**
-   
-   Crea una carpeta para Quetzal en tu sistema. Recomendamos:
-   
-   ```
-   C:\quetzal\
-   ```
-   
-   Mueve el archivo `quetzal.exe` descargado a esta carpeta.
-
-3. **Configurar variables de entorno**
-   
-   Para poder ejecutar Quetzal desde cualquier ubicación:
-   
-   - Presiona `Win + R`, escribe `sysdm.cpl` y presiona Enter
-   - Ve a la pestaña **"Opciones avanzadas"**
-   - Haz clic en **"Variables de entorno"**
-   - En **"Variables del sistema"**, busca la variable `Path` y haz clic en **"Editar"**
-   - Haz clic en **"Nuevo"** y agrega la ruta: `C:\quetzal`
-   - Haz clic en **"Aceptar"** en todas las ventanas
-
-4. **Verificar la instalación**
-   
-   Abre una nueva ventana de **Command Prompt** o **PowerShell** y ejecuta:
-   
-   ```cmd
-   quetzal --version
-   ```
-   
-   Deberías ver algo como:
-   ```
-   Lenguaje Quetzal v0.0.1
-   ```
-
-</Steps>
-
-## Uso básico
-
-### Ejecutar un archivo Quetzal
-
-```cmd
-quetzal mi_programa.qz
+```bash
+rustc --version
+cargo --version
+git --version
 ```
 
-### Ver ayuda
+## Obtener el código fuente
 
-```cmd
-quetzal --ayuda
+```bash
+git clone https://github.com/AntaresGT/lenguaje-quetzal.git
+cd lenguaje-quetzal
+git checkout v0.0.12
 ```
 
-## Verificación rápida
+La rama `v0.0.12` contiene los ejemplos referenciados en esta documentación y la versión más reciente del intérprete.
 
-Crea un archivo llamado `prueba.qz` con el siguiente contenido:
+## Compilación
 
-```qz
-imprimir_exito("¡Lenguaje Quetzal instalado correctamente!")
+Ejecuta `cargo build --release` para compilar el intérprete optimizado:
 
-entero edad = 25
-cadena nombre = "María"
+```bash
+cargo build --release
+```
 
-imprimir("Hola " + nombre + ", tienes " + edad.cadena() + " años")
+El binario generado se ubica en `target/release/quetzal` (Linux y macOS) o `target\release\quetzal.exe` (Windows).
 
-si (edad >= 18) {
-    imprimir("Eres mayor de edad")
-} sino {
-    imprimir("Eres menor de edad")
+## Ejecución de archivos `.qz`
+
+Crea un archivo de prueba con alguno de los ejemplos disponibles:
+
+```bash
+cp ejemplos/consola.qz pruebas-ia/consola.qz
+```
+
+Ejecuta el programa indicando la ruta del archivo:
+
+```bash
+./target/release/quetzal pruebas-ia/consola.qz
+```
+
+Si estás en Windows, utiliza:
+
+```powershell
+.\target\release\quetzal.exe pruebas-ia\consola.qz
+```
+
+## Configuración opcional con `quetzal.json`
+
+El intérprete lee un archivo `quetzal.json` ubicado junto al programa principal para definir permisos de ejecución, especialmente al importar módulos desde el sistema de archivos. Un ejemplo mínimo:
+
+```json
+{
+  "versión": "1.0.0",
+  "aplicación": "mi-proyecto",
+  "permisos": [
+    {
+      "nombre": "sistema-archivos",
+      "alcance": "directorios",
+      "directorios": ["./modulos"]
+    }
+  ]
 }
 ```
 
-Ejecuta el archivo:
+## Extensión de VS Code
 
-```cmd
-quetzal prueba.qz
+La extensión oficial **Lenguaje Quetzal** proporciona resaltado de sintaxis, ejecución directa y fragmentos reutilizables. Instálala desde la línea de comandos:
+
+```bash
+code --install-extension AntaresGT.lenguaje-quetzal-vscode-extension
 ```
 
-Si ves la salida correcta, ¡la instalación fue exitosa!
-
-## Solución de problemas
-
-<CardGrid>
-  <Card title="Comando no reconocido" icon="error">
-    **Error**: `'quetzal' no se reconoce como un comando interno o externo`
-    
-    **Solución**:
-    - Verifica que agregaste la ruta correcta al PATH
-    - Reinicia Command Prompt/PowerShell después de cambiar variables de entorno
-    - Asegúrate de que el archivo esté en `C:\quetzal\quetzal.exe`
-  </Card>
-  
-  <Card title="Error de permisos" icon="warning">
-    **Error**: No se puede ejecutar el archivo
-    
-    **Solución**:
-    - Ejecuta Command Prompt como administrador
-    - Verifica que tienes permisos de lectura en la carpeta de instalación
-    - Asegúrate de que Windows no está bloqueando el archivo (clic derecho > Propiedades > Desbloquear)
-  </Card>
-  
-  <Card title="Antivirus bloquea el archivo" icon="shield">
-    **Error**: El antivirus detecta el archivo como amenaza
-    
-    **Solución**:
-    - Agrega `C:\quetzal\` a las excepciones de tu antivirus
-    - Descarga nuevamente desde GitHub Releases oficial
-    - Reporta el falso positivo a tu proveedor de antivirus
-  </Card>
-</CardGrid>
-
-### Comandos de diagnóstico
-
-```cmd
-# Verificar que el archivo existe
-dir C:\quetzal\quetzal.exe
-
-# Verificar variables de entorno
-echo %PATH%
-
-# Ejecutar con información detallada
-quetzal --info
-```
-
-## Actualizar Quetzal
-
-Para actualizar a una nueva versión:
-
-1. Descarga la nueva versión de `quetzal.exe` desde GitHub Releases
-2. Reemplaza el archivo anterior en `C:\quetzal\`
-3. Verifica la nueva versión con `quetzal --version`
-
-## Desinstalar
-
-Para eliminar Quetzal de tu sistema:
-
-1. Elimina la carpeta `C:\quetzal\`
-2. Remueve `C:\quetzal` de la variable de entorno PATH
-3. (Opcional) Elimina cualquier archivo `.qz` que hayas creado
-
-## Próximos pasos
-
-¡Perfecto! Ya tienes Lenguaje Quetzal listo para usar. Continúa con:
-
-<CardGrid>
-  <Card title="Tu primer programa" icon="rocket">
-    Aprende a crear y ejecutar tu primer programa completo en Quetzal.
-    
-    [Crear primer programa →](/introduccion/primer-programa)
-  </Card>
-  
-  <Card title="Sintaxis básica" icon="document">
-    Familiarízate con la sintaxis y estructura del lenguaje.
-    
-    [Aprender sintaxis →](/fundamentos/sintaxis-basica)
-  </Card>
-  
-  <Card title="Ejemplos prácticos" icon="open-book">
-    Explora ejemplos de código para diferentes casos de uso.
-    
-    [Ver ejemplos →](/ejemplos/basicos)
-  </Card>
-</CardGrid>
-
----
-
-¿Problemas con la instalación? [Reporta un issue](https://github.com/AntaresGT/lenguaje-quetzal/issues) en nuestro repositorio de GitHub.
+Con esto tendrás el entorno listo para seguir el resto de la documentación.

--- a/src/content/docs/introduccion/primer-programa.mdx
+++ b/src/content/docs/introduccion/primer-programa.mdx
@@ -1,266 +1,77 @@
 ---
-title: Tu primer programa en Quetzal
-description: Tutorial paso a paso para crear y ejecutar tu primer programa completo en Lenguaje Quetzal.
+title: Tu primer programa
+description: Guía paso a paso para crear y ejecutar un archivo de Lenguaje Quetzal desde cero.
 ---
 
-import { Card, CardGrid, Steps, Code, Tabs, TabItem, Badge } from '@astrojs/starlight/components';
+## 1. Crear la carpeta del proyecto
 
-En este tutorial crearás y ejecutarás tu primer programa completo en Lenguaje Quetzal, explorando las características básicas del lenguaje.
+En un directorio de trabajo crea una carpeta para tus experimentos y agrega la configuración opcional de permisos:
 
-## ¡Hola, mundo!
+```bash
+mkdir -p proyectos/mi-primer-quetzal
+cd proyectos/mi-primer-quetzal
+cat <<'JSON' > quetzal.json
+{
+  "versión": "1.0.0",
+  "aplicación": "mi-primer-quetzal",
+  "permisos": []
+}
+JSON
+```
 
-Comencemos con el clásico programa "Hola, mundo":
+## 2. Escribir el programa
 
-<Steps>
-
-1. **Crear el archivo**
-   
-   Crea un nuevo archivo llamado `hola_mundo.qz` en tu carpeta preferida.
-
-2. **Escribir el código**
-   
-   ```qz
-   // Mi primer programa en Lenguaje Quetzal
-   imprimir("¡Hola, mundo desde Quetzal!")
-   ```
-
-3. **Ejecutar el programa**
-   
-   Abre Command Prompt o PowerShell en la carpeta donde guardaste el archivo y ejecuta:
-   
-   ```cmd
-   quetzal hola_mundo.qz
-   ```
-
-4. **Resultado esperado**
-   
-   ```
-   ¡Hola, mundo desde Quetzal!
-   ```
-
-</Steps>
-
-¡Felicidades! Acabas de ejecutar tu primer programa en Quetzal.
-
-## Programa completo paso a paso
-
-Ahora crearemos un programa más completo que demuestre varias características del lenguaje:
-
-### Código completo
-
-Crea un archivo llamado `mi_primer_programa.qz`:
+Crea un archivo `hola.qz` con el siguiente contenido:
 
 ```qz
-/*
- Mi primer programa completo en Lenguaje Quetzal
- Autor: Tu nombre
- Fecha: Hoy
-*/
+// hola.qz
+consola.mostrar_exito("Hola desde Lenguaje Quetzal")
 
-imprimir_exito("=== MI PRIMER PROGRAMA EN QUETZAL ===")
+lista<entero> numeros = [1, 2, 3, 4, 5]
 
-// ===== VARIABLES Y TIPOS =====
-imprimir_informacion("1. Trabajando con variables...")
-
-// Tipos básicos
-entero edad = 25
-cadena nombre = "Ana García"
-número salario = 2500.50
-bool esta_empleado = verdadero
-
-// Mostrar variables
-imprimir("Nombre: " + nombre)
-imprimir("Edad: " + edad.cadena() + " años")
-imprimir("Salario: $" + salario.cadena())
-imprimir("Empleado: " + esta_empleado.cadena())
-
-// ===== LISTAS =====
-imprimir_informacion("2. Trabajando con listas...")
-
-lista<cadena> hobbies = ["programar", "leer", "viajar", "cocinar"]
-lista<entero> numeros_favoritos = [7, 13, 21, 42]
-
-imprimir("Hobbies: " + hobbies.cadena())
-imprimir("Números favoritos: " + numeros_favoritos.cadena())
-
-// ===== FUNCIONES =====
-imprimir_informacion("3. Usando funciones...")
-
-// Función para calcular área de un círculo
-número calcular_area_circulo(número radio) {
-    número pi = 3.14159
-    retornar pi * radio * radio
+entero suma_total = 0
+para (entero var numero en numeros) {
+    suma_total += numero
 }
 
-// Función para crear saludo personalizado
-cadena crear_saludo(cadena nombre_persona, entero edad_persona) {
-    si (edad_persona >= 18) {
-        retornar "Hola " + nombre_persona + ", eres mayor de edad"
-    } sino {
-        retornar "Hola " + nombre_persona + ", eres menor de edad"
-    }
-}
-
-// Usar las funciones
-número area = calcular_area_circulo(5.0)
-cadena saludo = crear_saludo(nombre, edad)
-
-imprimir("Área del círculo (radio 5): " + area.cadena())
-imprimir(saludo)
-
-// ===== CONDICIONALES =====
-imprimir_informacion("4. Usando condicionales...")
-
-entero puntuacion = 85
-
-si (puntuacion >= 90) {
-    imprimir("Calificación: Excelente")
-} sino si (puntuacion >= 80) {
-    imprimir("Calificación: Muy bueno")
-} sino si (puntuacion >= 70) {
-    imprimir("Calificación: Bueno")
-} sino {
-    imprimir("Calificación: Necesita mejorar")
-}
-
-// ===== BUCLES =====
-imprimir_informacion("5. Usando bucles...")
-
-imprimir("Contando del 1 al 5:")
-para (entero i = 1; i <= 5; i++) {
-    imprimir("Número: " + i.cadena())
-}
-
-imprimir("Recorriendo hobbies:")
-para (cadena hobby en hobbies) {
-    imprimir("- " + hobby)
-}
-
-// ===== OBJETOS JSON =====
-imprimir_informacion("6. Trabajando con JSON...")
-
-jsn persona = {
-    nombre: nombre,
-    edad: edad,
-    salario: salario,
-    hobbies: hobbies,
-    contacto: {
-        email: "ana@ejemplo.com",
-        telefono: "+502 1234-5678"
-    },
-    activo: verdadero
-}
-
-imprimir("Datos de la persona:")
-imprimir(persona.cadena())
-
-// ===== OPERACIONES MATEMÁTICAS =====
-imprimir_informacion("7. Operaciones matemáticas...")
-
-entero a = 15
-entero b = 4
-
-imprimir("Operaciones con " + a.cadena() + " y " + b.cadena() + ":")
-imprimir("Suma: " + (a + b).cadena())
-imprimir("Resta: " + (a - b).cadena())
-imprimir("Multiplicación: " + (a * b).cadena())
-imprimir("División: " + (a / b).cadena())
-imprimir("Módulo: " + (a % b).cadena())
-
-// ===== VARIABLES MUTABLES =====
-imprimir_informacion("8. Variables mutables...")
-
-entero mut contador = 0
-imprimir("Contador inicial: " + contador.cadena())
-
-contador = contador + 10
-imprimir("Contador después de sumar 10: " + contador.cadena())
-
-contador += 5
-imprimir("Contador después de += 5: " + contador.cadena())
-
-// ===== FINAL =====
-imprimir_exito("¡Programa completado exitosamente!")
-imprimir("Has aprendido los conceptos básicos de Lenguaje Quetzal:")
-imprimir("✓ Variables y tipos de datos")
-imprimir("✓ Funciones")
-imprimir("✓ Condicionales")
-imprimir("✓ Bucles")
-imprimir("✓ Listas")
-imprimir("✓ Objetos JSON")
-imprimir("✓ Operaciones matemáticas")
-imprimir("✓ Variables mutables")
+consola.mostrar(t"Suma: {suma_total}")
 ```
 
-### Ejecutar el programa
+El ejemplo utiliza listas, bucles y cadenas interpoladas (`t"..."`) para mostrar valores calculados.
 
-```cmd
-quetzal mi_primer_programa.qz
+## 3. Compilar el intérprete (una sola vez)
+
+Desde la carpeta clonada del proyecto `lenguaje-quetzal` ejecuta:
+
+```bash
+cargo build --release
 ```
 
-### Salida esperada
+## 4. Ejecutar el programa
 
-```cmd
-=== MI PRIMER PROGRAMA EN QUETZAL ===
-1. Trabajando con variables...
-Nombre: Ana García
-Edad: 25 años
-Salario: $2500.5
-Empleado: Sí
-2. Trabajando con listas...
-Hobbies: [programar, leer, viajar, cocinar]
-Números favoritos: [7, 13, 21, 42]
-3. Usando funciones...
-Área del círculo (radio 5): 78.53975
-Hola Ana García, eres mayor de edad
-4. Usando condicionales...
-Calificación: Muy bueno
-5. Usando bucles...
-Contando del 1 al 5:
-Número: 1
-Número: 2
-Número: 3
-Número: 4
-Número: 5
-Recorriendo hobbies:
-- programar
-- leer
-- viajar
-- cocinar
-6. Trabajando con JSON...
-{
-    "nombre": "Ana García",
-    "edad": 25,
-    "salario": 2500.5,
-    "hobbies": ["programar", "leer", "viajar", "cocinar"],
-    "contacto": {
-        "email": "ana@ejemplo.com",
-        "telefono": "+502 12
-34-5678"
-    },
-    "activo": true
-}
-7. Operaciones matemáticas...
-Suma: 19
-Resta: 11
-División: 3
-Multiplicación: 60
-Módulo: 3
+Invoca el intérprete indicando la ruta absoluta o relativa del archivo:
 
-8. Variables mutables...
-Contador inicial: 0
-Contador después de sumar 10: 10
-Contador después de += 5: 15
-9. Final...
-¡Programa completado exitosamente!
-Has aprendido los conceptos básicos de Lenguaje Quetzal:
-✓ Variables y tipos de datos
-✓ Funciones
-✓ Condicionales
-✓ Bucles
-✓ Listas
-✓ Objetos JSON
-✓ Operaciones matemáticas
-✓ Variables mutables
+```bash
+/path/al/repositorio/target/release/quetzal /ruta/al/proyecto/hola.qz
+```
+
+El resultado esperado es:
 
 ```
+Hola desde Lenguaje Quetzal
+Suma: 15
+```
+
+Los colores dependen del soporte de tu terminal.
+
+## 5. Explorar más ejemplos
+
+Prueba otros archivos de la carpeta `ejemplos` del repositorio, por ejemplo:
+
+```bash
+/path/al/repositorio/target/release/quetzal /path/al/repositorio/ejemplos/modulo_matematicas.qz
+```
+
+Esto imprime operaciones de la biblioteca `Matemática` incluida en la distribución.
+
+Con estos pasos ya puedes experimentar y modificar el código para aprender la sintaxis del lenguaje.

--- a/src/content/docs/io/archivos.mdx
+++ b/src/content/docs/io/archivos.mdx
@@ -1,16 +1,40 @@
 ---
-title: Manejo de Archivos
-description: Manejo de archivos en el Lenguaje Quetzal
+title: Manejo de archivos
+description: Estado del acceso a archivos y configuración mediante `quetzal.json`.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+La versión v0.0.12 del intérprete no expone todavía un API de lectura o escritura de archivos desde el código Quetzal. No existen funciones nativas como `consola` para interactuar directamente con el sistema de archivos.
 
-Esta sección necesita ser completada con información sobre el manejo de archivos en el Lenguaje Quetzal.
+## Uso actual: módulos externos
 
-## Contenido pendiente:
-- Leer archivos
-- Escribir archivos
-- Modos de apertura
-- Rutas de archivos
-- Manejo de errores de E/S
-- Ejemplos de uso
+Los permisos a archivos se gestionan desde `quetzal.json`. Este archivo se coloca junto al programa principal y define qué directorios pueden explorarse al importar módulos.
+
+```json
+{
+  "versión": "1.0.0",
+  "aplicación": "mi-proyecto",
+  "permisos": [
+    {
+      "nombre": "sistema-archivos",
+      "alcance": "directorios",
+      "directorios": ["./modulos", "./datos"]
+    }
+  ]
+}
+```
+
+Cuando importas un módulo:
+
+```qz
+importar { utilidades } desde "./modulos/utilidades.qz"
+```
+
+El intérprete verifica que la ruta esté permitida. Si no, mostrará un error indicando que el acceso al sistema de archivos está restringido.
+
+## Buenas prácticas mientras llega el API de archivos
+
+- Mantén tus módulos dentro de los directorios autorizados para evitar errores de permisos.
+- No expongas rutas absolutas sensibles; utiliza rutas relativas desde el archivo principal.
+- Documenta en tus proyectos qué carpetas deben agregarse al arreglo `directorios` para que otras personas puedan ejecutarlos sin modificar el código.
+
+Esta sección se actualizará cuando el lenguaje incluya funciones para leer o escribir archivos directamente.

--- a/src/content/docs/io/consola.mdx
+++ b/src/content/docs/io/consola.mdx
@@ -1,16 +1,47 @@
 ---
-title: Entrada y Salida por Consola
-description: Entrada y salida por consola en el Lenguaje Quetzal
+title: Consola
+description: Operaciones de entrada y salida disponibles mediante `consola`.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+El objeto global `consola` ofrece métodos para mostrar mensajes con formato y solicitar datos al usuario.
 
-Esta sección necesita ser completada con información sobre entrada y salida por consola en el Lenguaje Quetzal.
+## Mostrar mensajes
 
-## Contenido pendiente:
-- Imprimir en consola
-- Leer desde consola
-- Formateo de salida
-- Colores en consola
-- Entrada de diferentes tipos
-- Ejemplos de uso
+| Método | Descripción |
+|--------|-------------|
+| `consola.mostrar(texto)` | Imprime texto con el color por defecto. |
+| `consola.mostrar_error(texto)` | Imprime en rojo. |
+| `consola.mostrar_advertencia(texto)` | Imprime en amarillo. |
+| `consola.mostrar_exito(texto)` | Imprime en verde. |
+| `consola.mostrar_informacion(texto)` | Imprime en azul. |
+
+```qz
+consola.mostrar("Inicio del programa")
+consola.mostrar_exito("Operación completada")
+consola.mostrar_error("No se pudo cargar el archivo")
+```
+
+## Solicitar datos
+
+```qz
+texto nombre = consola.pedir("Ingresa tu nombre:")
+texto clave = consola.pedir_secreto("Contraseña:")
+```
+
+- `pedir` muestra un mensaje y devuelve el texto introducido por el usuario.
+- `pedir_secreto` oculta la entrada (útil para contraseñas).
+
+## Interpolación con `consola`
+
+Aprovecha cadenas interpoladas (`t"..."`) para incluir valores calculados.
+
+```qz
+número resultado = 5 + 3
+consola.mostrar(t"Resultado: {resultado}")
+```
+
+## Consideraciones
+
+- Las funciones de `consola` están disponibles en todo el programa sin necesidad de importarlas.
+- El color de salida depende del soporte de tu terminal.
+- Cuando ejecutes el intérprete dentro de scripts automatizados, evita solicitar entradas interactivas.

--- a/src/content/docs/modulos/importar-exportar.mdx
+++ b/src/content/docs/modulos/importar-exportar.mdx
@@ -1,16 +1,67 @@
 ---
-title: Importar y Exportar Módulos
-description: Sistema de módulos en el Lenguaje Quetzal
+title: Importar y exportar
+description: Compartir código entre archivos en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Exportar símbolos
 
-Esta sección necesita ser completada con información sobre el sistema de importación y exportación en el Lenguaje Quetzal.
+Al final de un archivo declara qué elementos estarán disponibles para otros módulos.
 
-## Contenido pendiente:
-- Sintaxis de import
-- Sintaxis de export
-- Importaciones nombradas
-- Importaciones por defecto
-- Alias de importación
-- Ejemplos de uso
+```qz
+entero sumar_entero(entero a, entero b) {
+    retornar a + b
+}
+
+objeto Usuario {
+    publico:
+        Usuario(texto nombre) {
+            ambiente.nombre = nombre
+        }
+}
+
+Usuario instancia_usuario = nuevo Usuario("Ana")
+texto saludo = "Hola"
+
+exportar {
+    sumar_entero,
+    Usuario,
+    instancia_usuario,
+    saludo
+}
+```
+
+Puedes exportar funciones, objetos, instancias y variables.
+
+## Importar símbolos
+
+```qz
+importar {
+    sumar_entero,
+    Usuario,
+    instancia_usuario,
+    saludo como saludo_texto
+} desde "./modulos/exportar.qz"
+```
+
+- Las llaves listan los símbolos que deseas usar.
+- `como` permite asignar un alias local.
+- La ruta puede ser relativa (`./modulos/exportar.qz`) o un módulo nativo como `"quetzal/matemática"`.
+
+## Importar todo un módulo nativo
+
+```qz
+importar {
+    Matemática
+} desde "quetzal/matemática"
+
+número resultado = Matemática.sumar(2, 3)
+```
+
+Los módulos nativos se distribuyen con el intérprete y no requieren permisos adicionales.
+
+## Consideraciones
+
+- Si intentas importar un símbolo no exportado, el intérprete mostrará un error indicando que el elemento no está disponible.
+- Las rutas deben terminar en `.qz` cuando se trata de archivos del sistema.
+- El intérprete mantiene un caché de módulos; los cambios en un archivo requieren volver a ejecutar el programa.
+- Evita importaciones circulares. Organiza el código en capas o utiliza módulos intermedios para compartir dependencias comunes.

--- a/src/content/docs/modulos/organizacion.mdx
+++ b/src/content/docs/modulos/organizacion.mdx
@@ -1,16 +1,73 @@
 ---
-title: Organización de Código
-description: Mejores prácticas para organizar código en Quetzal
+title: Organización de módulos
+description: Cómo estructurar proyectos de Lenguaje Quetzal con múltiples archivos.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Estructura recomendada
 
-Esta sección necesita ser completada con información sobre la organización de código en el Lenguaje Quetzal.
+```
+mi-proyecto/
+├── quetzal.json
+├── principal.qz
+├── modulos/
+│   ├── usuarios.qz
+│   └── utilidades.qz
+└── datos/
+    └── ejemplos.json
+```
 
-## Contenido pendiente:
-- Estructura de proyectos
-- Convenciones de nombres
-- Separación de responsabilidades
-- Modularización
-- Documentación de código
-- Ejemplos de uso
+- `principal.qz` contiene el punto de entrada.
+- La carpeta `modulos` agrupa código reutilizable.
+- `quetzal.json` declara permisos (especialmente para el sistema de archivos).
+
+## Archivo `quetzal.json`
+
+```json
+{
+  "versión": "1.0.0",
+  "aplicación": "mi-proyecto",
+  "permisos": [
+    {
+      "nombre": "sistema-archivos",
+      "alcance": "directorios",
+      "directorios": ["./modulos", "./datos"]
+    }
+  ]
+}
+```
+
+Este archivo es opcional, pero recomendado si importarás módulos desde el sistema de archivos. Sin permisos, el intérprete solo permite módulos internos al ejecutable.
+
+## Nomenclatura de archivos
+
+- Los archivos de código usan la extensión `.qz`.
+- Emplea nombres en minúsculas con guiones medios o bajos (`usuarios.qz`, `procesamiento_texto.qz`).
+- Evita espacios o caracteres especiales.
+
+## Exportaciones claras
+
+Cada módulo puede terminar con un bloque `exportar` que indique qué símbolos estarán disponibles para otros archivos.
+
+```qz
+exportar {
+    sumar_entero,
+    Usuario,
+    instancia_usuario,
+    saludo
+}
+```
+
+## Importaciones relativas
+
+Las rutas son relativas al archivo principal que invoca al intérprete. Usa `./` para rutas locales o carpetas autorizadas en `quetzal.json`.
+
+```qz
+importar { Usuario } desde "./modulos/usuarios.qz"
+```
+
+## Buenas prácticas
+
+- Mantén funciones relacionadas en el mismo archivo para facilitar su descubrimiento.
+- Separa la lógica de dominio y la infraestructura en módulos diferentes.
+- Documenta en comentarios cualquier dependencia entre módulos.
+- Al compartir proyectos, incluye instrucciones para copiar `quetzal.json` y las carpetas permitidas.

--- a/src/content/docs/oop/clases-objetos.mdx
+++ b/src/content/docs/oop/clases-objetos.mdx
@@ -1,16 +1,107 @@
 ---
-title: Clases y Objetos
-description: Programación orientada a objetos en el Lenguaje Quetzal
+title: Objetos
+description: Definición y uso de objetos en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Los objetos en Quetzal permiten agrupar datos y comportamientos. Se definen con la palabra clave `objeto` seguida del nombre y un bloque de miembros.
 
-Esta sección necesita ser completada con información sobre clases y objetos en el Lenguaje Quetzal.
+## Declaración básica
 
-## Contenido pendiente:
-- Definición de clases
-- Instanciación de objetos
-- Propiedades y métodos
-- Herencia
-- Polimorfismo
-- Ejemplos de uso
+```qz
+objeto Usuario {
+    texto nombre
+    entero edad
+
+    Usuario(texto nombre, entero edad) {
+        ambiente.nombre = nombre
+        ambiente.edad = edad
+    }
+
+    texto obtener_nombre() {
+        retornar ambiente.nombre
+    }
+}
+```
+
+- Los atributos declarados fuera de `privado` o `publico` son públicos por defecto.
+- Los constructores usan el mismo nombre del objeto y no retornan valor explícito.
+
+## Instanciación
+
+```qz
+Usuario persona = nuevo Usuario("María", 30)
+texto nombre = persona.obtener_nombre()
+```
+
+## Bloques `privado` y `publico`
+
+```qz
+objeto Banco {
+    privado:
+        número var saldo = 0
+
+        número obtener_saldo_privado() {
+            retornar ambiente.saldo
+        }
+
+    publico:
+        Banco(número inicial) {
+            ambiente.saldo = inicial
+        }
+
+        número obtener_saldo() {
+            retornar ambiente.obtener_saldo_privado()
+        }
+}
+```
+
+- Los miembros dentro de `privado` solo están disponibles dentro del objeto.
+- Los miembros en `publico` pueden usarse desde cualquier parte.
+
+## Miembros libres
+
+Los miembros declarados con la palabra `libre` actúan como miembros estáticos: pueden invocarse sin crear una instancia y no acceden al estado del objeto instanciado.
+
+```qz
+objeto MatematicaBasica {
+    libre número PI = 3.14159
+
+    libre número sumar(número a, número b) {
+        retornar a + b
+    }
+}
+
+número resultado = MatematicaBasica.sumar(2, 3)
+```
+
+## Mutabilidad de atributos
+
+- Los atributos son inmutables a menos que se declaren con `var` dentro del objeto.
+- Para modificar desde métodos públicos usa `ambiente`.
+
+```qz
+objeto Contador {
+    entero var valor = 0
+
+    vacio incrementar() {
+        ambiente.valor++
+    }
+}
+```
+
+## Herencia
+
+Lenguaje Quetzal no incluye herencia clásica. Recomienda composición: crea objetos que utilicen a otros internamente o expón funciones libres reutilizables.
+
+## Exportar objetos
+
+Los objetos pueden exportarse desde un módulo y reutilizarse en otros archivos.
+
+```qz
+exportar {
+    Usuario,
+    Banco
+}
+```
+
+Consulta las secciones de constructores y modificadores de acceso para profundizar en cada característica.

--- a/src/content/docs/oop/constructores.mdx
+++ b/src/content/docs/oop/constructores.mdx
@@ -1,16 +1,91 @@
 ---
-title: Constructores de Clases
-description: Constructores de clases en el Lenguaje Quetzal
+title: Constructores
+description: Cómo inicializar objetos en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Los constructores comparten el nombre del objeto y no declaran tipo de retorno. Se ejecutan cuando usas la palabra clave `nuevo`.
 
-Esta sección necesita ser completada con información sobre los constructores en el Lenguaje Quetzal.
+## Estructura general
 
-## Contenido pendiente:
-- Definición de constructores
-- Constructores con parámetros
-- Constructores por defecto
-- Sobrecarga de constructores
-- Inicialización de propiedades
-- Ejemplos de uso
+```qz
+objeto Punto {
+    número x
+    número y
+
+    Punto(número x, número y) {
+        ambiente.x = x
+        ambiente.y = y
+    }
+}
+```
+
+## Inicialización de atributos
+
+Dentro del constructor utiliza `ambiente` para asignar valores a los atributos.
+
+```qz
+objeto Usuario {
+    privado:
+        texto nombre
+        entero edad
+    publico:
+        Usuario(texto nombre, entero edad) {
+            ambiente.nombre = nombre
+            ambiente.edad = edad
+        }
+}
+```
+
+## Validaciones en el constructor
+
+Puedes incluir lógica para validar los argumentos y lanzar excepciones si algo no es válido.
+
+```qz
+objeto CuentaBancaria {
+    privado:
+        número var saldo
+    publico:
+        CuentaBancaria(número saldo_inicial) {
+            si (saldo_inicial < 0) {
+                lanzar "El saldo inicial no puede ser negativo"
+            }
+            ambiente.saldo = saldo_inicial
+        }
+}
+```
+
+## Constructores y `var`
+
+- Declara atributos mutables con `var` dentro del objeto.
+- Las listas y valores `jsn` creados dentro del constructor pueden modificarse posteriormente desde métodos públicos.
+
+```qz
+objeto Inventario {
+    privado:
+        lista<texto> var articulos
+    publico:
+        Inventario() {
+            ambiente.articulos = []
+        }
+
+        vacio agregar(texto articulo) {
+            ambiente.articulos.agregar(articulo)
+        }
+}
+```
+
+## Constructores sin parámetros
+
+Puedes omitir parámetros si el objeto tiene valores predeterminados.
+
+```qz
+objeto Configuracion {
+    log var modo_debug = falso
+
+    Configuracion() {
+        // Valores por defecto ya asignados
+    }
+}
+```
+
+Recuerda que los constructores no pueden usar `retornar`; cualquier intento generará un error de análisis.

--- a/src/content/docs/oop/modificadores-acceso.mdx
+++ b/src/content/docs/oop/modificadores-acceso.mdx
@@ -1,16 +1,64 @@
 ---
-title: Modificadores de Acceso
-description: Control de acceso en clases del Lenguaje Quetzal
+title: Modificadores de acceso
+description: Control de visibilidad en objetos de Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Los objetos utilizan bloques para agrupar miembros con la misma visibilidad.
 
-Esta sección necesita ser completada con información sobre los modificadores de acceso en el Lenguaje Quetzal.
+## `publico`
 
-## Contenido pendiente:
-- Público (public)
-- Privado (private)
-- Protegido (protected)
-- Encapsulación
-- Getters y setters
-- Ejemplos de uso
+Los miembros definidos en el bloque `publico` están disponibles fuera del objeto.
+
+```qz
+objeto Usuario {
+    publico:
+        texto nombre
+
+        Usuario(texto nombre) {
+            ambiente.nombre = nombre
+        }
+}
+
+Usuario persona = nuevo Usuario("Ana")
+consola.mostrar(persona.nombre)
+```
+
+## `privado`
+
+Los miembros privados solo pueden usarse dentro del objeto. Son útiles para encapsular detalles internos.
+
+```qz
+objeto Tokenizador {
+    privado:
+        lista<texto> palabras_reservadas = ["si", "sino", "para"]
+    publico:
+        log es_reservada(texto palabra) {
+            retornar ambiente.palabras_reservadas.contiene(palabra)
+        }
+}
+```
+
+Intentar acceder a `palabras_reservadas` desde fuera del objeto produce un error.
+
+## Miembros libres
+
+Dentro de `publico` o `privado` puedes marcar miembros como `libre`. Estos actúan como miembros estáticos que no requieren instancias y no acceden a `ambiente`.
+
+```qz
+objeto UtilidadesTexto {
+    publico:
+        libre texto unir(texto a, texto b) {
+            retornar a + b
+        }
+}
+
+texto combinado = UtilidadesTexto.unir("Hola", " Quetzal")
+```
+
+## Reglas adicionales
+
+- Los atributos y métodos declarados antes de cualquier bloque son públicos.
+- Un objeto puede mezclar bloques `privado` y `publico`. Cada bloque puede aparecer varias veces si lo necesitas para organizar el código.
+- Los miembros privados pueden llamar a métodos públicos del mismo objeto mediante `ambiente`.
+
+El uso adecuado de los modificadores facilita mantener invariantes y separar la API pública de los detalles internos.

--- a/src/content/docs/referencia/funciones-integradas.mdx
+++ b/src/content/docs/referencia/funciones-integradas.mdx
@@ -1,16 +1,54 @@
 ---
-title: Funciones Integradas
-description: Funciones integradas del Lenguaje Quetzal
+title: Funciones integradas
+description: Funciones proporcionadas por el intérprete de Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+Estas funciones están disponibles sin necesidad de importarlas.
 
-Esta sección necesita ser completada con información sobre las funciones integradas en el Lenguaje Quetzal.
+## Alias de consola
 
-## Contenido pendiente:
-- Lista de funciones integradas
-- Funciones matemáticas
-- Funciones de cadena
-- Funciones de tipo
-- Funciones de entrada/salida
-- API de referencia completa
+| Función | Equivalente en `consola` | Descripción |
+|---------|--------------------------|-------------|
+| `imprimir(texto)` | `consola.mostrar` | Muestra texto con el color por defecto. |
+| `imprimir_error(texto)` | `consola.mostrar_error` | Muestra mensajes de error. |
+| `imprimir_advertencia(texto)` | `consola.mostrar_advertencia` | Mensajes de advertencia. |
+| `imprimir_informacion(texto)` | `consola.mostrar_informacion` | Mensajes informativos. |
+| `imprimir_exito(texto)` | `consola.mostrar_exito` | Mensajes de éxito. |
+| `imprimir_alerta(texto)` | `consola.mostrar_alerta` | Mensajes que requieren atención. |
+| `imprimir_confirmacion(texto)` | `consola.mostrar_confirmacion` | Mensajes de confirmación. |
+| `imprimir_depurar(texto)` | `consola.mostrar_depurar` | Salida destinada a depuración. |
+
+Todas aceptan una única cadena (`texto`). Si necesitas mostrar otros tipos, conviértelos mediante `.texto()` o utiliza cadenas interpoladas `t"..."`.
+
+## `rango`
+
+Genera listas de enteros consecutivos.
+
+```qz
+lista<entero> del_cero_al_cinco = rango(5)        // [0, 1, 2, 3, 4]
+lista<entero> de_dos_a_cinco = rango(2, 5)       // [2, 3, 4]
+```
+
+- Con un argumento (`rango(fin)`) crea una lista desde `0` hasta `fin - 1`.
+- Con dos argumentos (`rango(inicio, fin)`) crea una lista desde `inicio` hasta `fin - 1`.
+- Los argumentos deben ser enteros no negativos y `inicio` no puede ser mayor que `fin`.
+
+## Métodos de conversión
+
+Aunque se invocan como métodos (`valor.texto()`, `cadena.entero()`), forman parte del conjunto estándar del lenguaje y están disponibles para todos los valores. Revisa la sección de **Conversión de tipos** para conocerlos a detalle.
+
+## Módulos nativos
+
+El intérprete distribuye el módulo `quetzal/matemática` con funciones adicionales:
+
+- `Matemática.sumar`, `Matemática.restar`, `Matemática.multiplicar`, `Matemática.dividir`
+- Operaciones avanzadas: `potencia`, `promedio`, `maximo`, `minimo`, `hipotenusa`, `logaritmo_base`, entre otras.
+- Constantes: `Matemática.PI`, `Matemática.TAU`, `Matemática.E`.
+
+Para usarlo, importa el módulo antes de llamar a sus funciones.
+
+```qz
+importar { Matemática } desde "quetzal/matemática"
+```
+
+La documentación de cada módulo nativo se amplía conforme se publiquen nuevas versiones.

--- a/src/content/docs/referencia/gramatica.mdx
+++ b/src/content/docs/referencia/gramatica.mdx
@@ -1,16 +1,118 @@
 ---
-title: Gramática Formal del Lenguaje Quetzal
-description: Gramática formal del Lenguaje Quetzal
+title: Gramática
+description: Visión general de la gramática de Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+La siguiente descripción resume las construcciones más importantes del lenguaje. No es una especificación formal completa, pero sirve como referencia rápida.
 
-Esta sección necesita ser completada con la gramática formal completa del Lenguaje Quetzal.
+## Programas
 
-## Contenido pendiente:
-- Gramática BNF/EBNF
-- Reglas de sintaxis
-- Precedencia de operadores
-- Tokens y lexemas
-- Diagramas de sintaxis
-- Especificación formal
+Un archivo `.qz` contiene una secuencia de declaraciones separadas por saltos de línea:
+
+```
+programa      -> declaracion*
+declaracion   -> declaracion_variable
+               | declaracion_funcion
+               | declaracion_objeto
+               | declaracion_importacion
+               | declaracion_exportacion
+               | sentencia
+```
+
+## Declaraciones
+
+```
+declaracion_variable -> tipo identificador ('var')? ('=' expresion)?
+tipo -> 'vacio' | 'entero' | 'número' | 'texto' | 'log' | 'lista' '<' tipo '>' | 'lista' | 'jsn'
+
+declaracion_funcion  -> tipo identificador '(' parametros? ')' bloque
+parametros           -> parametro (',' parametro)*
+parametro            -> tipo ('var')? identificador
+
+Declaracion_objeto   -> 'objeto' identificador '{' miembros_objeto '}'
+miembros_objeto      -> (bloque_publico | bloque_privado | miembro_publico)*
+bloque_publico       -> 'publico:' miembro_publico*
+bloque_privado       -> 'privado:' miembro_privado*
+miembro_publico      -> declaracion_variable | declaracion_funcion | constructor | miembro_libre
+miembro_privado      -> igual que miembro_publico pero accesible solo dentro del objeto
+constructor          -> identificador '(' parametros? ')' bloque (sin `retornar`)
+miembro_libre        -> 'libre' declaracion_variable | 'libre' declaracion_funcion
+```
+
+## Sentencias
+
+```
+sentencia -> bloque
+           | sentencia_expr
+           | sentencia_si
+           | sentencia_mientras
+           | sentencia_para
+           | sentencia_hacer
+           | sentencia_intentar
+           | sentencia_romper
+           | sentencia_continuar
+           | sentencia_retornar
+           | sentencia_lanzar
+
+bloque -> '{' declaracion* '}'
+```
+
+### Condicionales y bucles
+
+```
+sentencia_si        -> 'si' '(' expresion ')' bloque ('sino' bloque)? ('sino' 'si' '(' expresion ')' bloque)*
+sentencia_mientras  -> 'mientras' '(' expresion ')' bloque
+sentencia_hacer     -> 'hacer' bloque 'mientras' '(' expresion ')'
+
+sentencia_para      -> 'para' '(' inicio_para condicion_para actualizacion_para ')' bloque
+inicio_para         -> declaracion_variable | sentencia_expr | ε
+condicion_para      -> expresion | ε
+actualizacion_para  -> expresion | ε
+
+// Iteración sobre colecciones
+sentencia_para      -> 'para' '(' tipo 'var' identificador ('en' | 'cada') expresion ')' bloque
+```
+
+### Manejo de errores
+
+```
+sentencia_intentar  -> 'intentar' bloque bloque_capturar+ bloque_finalmente?
+bloque_capturar     -> 'capturar' '(' 'excepcion' identificador ')' bloque
+bloque_finalmente   -> 'finalmente' bloque
+
+sentencia_lanzar    -> 'lanzar' expresion
+sentencia_retornar  -> 'retornar' expresion?
+```
+
+## Expresiones
+
+```
+expresion           -> expresion_asignacion
+expresion_asignacion-> expresion_logica (operador_asignacion expresion_asignacion)?
+operador_asignacion -> '=' | '+=' | '-=' | '*=' | '/=' | '%='
+
+expresion_logica    -> expresion_igualdad (('y' | 'o' | '&&' | '||') expresion_igualdad)*
+expresion_igualdad  -> expresion_comparacion (('==' | '!=') expresion_comparacion)*
+expresion_comparacion -> expresion_term (( '>' | '>=' | '<' | '<=' ) expresion_term)*
+expresion_term      -> expresion_factor (( '+' | '-' ) expresion_factor)*
+expresion_factor    -> expresion_unaria (( '*' | '/' | '%' ) expresion_unaria)*
+expresion_unaria    -> ( '!' | 'no' | '-' | '++' | '--' ) expresion_unaria | expresion_postfija
+expresion_postfija  -> expresion_primaria (postfijo)*
+postfijo            -> llamada | acceso_lista | acceso_propiedad | incremento | decremento
+llamada             -> '(' argumentos? ')'
+argumentos          -> expresion (',' expresion)*
+acceso_lista        -> '[' expresion ']'
+acceso_propiedad    -> '.' identificador
+incremento          -> '++'
+decremento          -> '--'
+
+expresion_primaria  -> literal
+                    | identificador
+                    | '(' expresion ')'
+                    | 'nuevo' identificador '(' argumentos? ')'
+                    | interpolacion_texto
+```
+
+Los literales incluyen números, texto entre comillas dobles, listas `[ ... ]`, objetos JSON `{ ... }`, valores `verdadero`, `falso` y `nulo`.
+
+Esta gramática resumida refleja el estado del lenguaje en v0.0.12. A medida que se agreguen características (como funciones asincrónicas o más módulos nativos) se actualizará este apartado.

--- a/src/content/docs/referencia/palabras-reservadas.mdx
+++ b/src/content/docs/referencia/palabras-reservadas.mdx
@@ -1,16 +1,42 @@
 ---
-title: Palabras Reservadas
-description: Palabras reservadas del Lenguaje Quetzal
+title: Palabras reservadas
+description: Lista de palabras que no pueden usarse como identificadores en Lenguaje Quetzal.
 ---
 
-🚧 **Esta documentación está en construcción** 🚧
+## Tipos de datos
 
-Esta sección necesita ser completada con la lista completa de palabras reservadas en el Lenguaje Quetzal.
+`vacio`, `entero`, `número`, `texto`, `log`, `lista`, `jsn`
 
-## Contenido pendiente:
-- Lista completa de palabras reservadas
-- Categorización por funcionalidad
-- Ejemplos de uso
-- Palabras reservadas futuras
-- Convenciones de nomenclatura
-- Tabla de referencia rápida
+## Modificadores y visibilidad
+
+`var`, `publico`, `privado`, `libre`, `ambiente`
+
+## Control de flujo
+
+`si`, `sino`, `sino si`, `para`, `mientras`, `hacer`, `romper`, `continuar`, `en`, `cada`, `retornar`
+
+## Objetos y creación de instancias
+
+`objeto`, `nuevo`, `constructor`
+
+## Asincronía reservada
+
+`asincrono`, `esperar`
+
+## Manejo de excepciones
+
+`intentar`, `capturar`, `finalmente`, `lanzar`, `excepcion`
+
+## Módulos
+
+`importar`, `exportar`, `desde`, `como`
+
+## Literales y operadores lógicos
+
+`verdadero`, `falso`, `nulo`, `y`, `o`, `no`
+
+## Otros identificadores protegidos
+
+`mut`, `de`, `es`
+
+Aunque algunas palabras (como `asincrono` o `mut`) aún no tienen implementación completa en v0.0.12, se reservan para futuras extensiones del lenguaje. Evita utilizarlas como nombres de variables, funciones, objetos o propiedades para prevenir errores de análisis.


### PR DESCRIPTION
## Summary
- actualizar la portada y la introducción con información de la versión v0.0.12, ejemplos funcionales y enlaces en formato compatible con MDX
- completar todas las secciones de fundamentos, control, datos, funciones, módulos, entrada/salida, POO, errores y referencia usando sintaxis real proveniente de la carpeta `ejemplos`
- renovar los ejemplos guiados y mejores prácticas, además de actualizar Astro, Starlight y TypeScript a sus versiones recientes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d440e485ec832fa5982fc44edcb9cc