### PR TITLE
Agregar soporte multilingüe con contenido base en español

### DIFF
--- a/scripts/generar_traducciones.py
+++ b/scripts/generar_traducciones.py
@@ -1,0 +1,106 @@
+"""Script para generar archivos de otros idiomas reutilizando el contenido en español."""
+import os
+import time
+from pathlib import Path
+import yaml
+import requests
+from requests import RequestException
+
+BASE_DOCS = Path('src/content/docs')
+IDIOMAS = {
+    'en': {
+        'codigo': 'en',
+        'mensaje': 'Translation in progress. The following content is temporarily shown in Spanish.',
+    },
+    'id': {
+        'codigo': 'id',
+        'mensaje': 'Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.',
+    },
+    'ja': {
+        'codigo': 'ja',
+        'mensaje': '翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。',
+    },
+}
+
+
+def cargar_frontmatter(ruta: Path) -> dict:
+    """Extrae el frontmatter YAML de un archivo MDX."""
+    contenido = ruta.read_text(encoding='utf-8')
+    partes = contenido.split('---', 2)
+    if len(partes) < 3:
+        raise ValueError(f'El archivo {ruta} no contiene un frontmatter válido')
+    return yaml.safe_load(partes[1])
+
+
+def crear_archivo_idioma(ruta_es: Path, idioma: str, datos_front: dict, mensaje: str) -> None:
+    """Genera un archivo MDX para un idioma específico reutilizando el contenido original."""
+    destino = BASE_DOCS / idioma / ruta_es.relative_to(BASE_DOCS)
+    destino.parent.mkdir(parents=True, exist_ok=True)
+    ruta_relativa = Path(
+        os.path.relpath(ruta_es, destino.parent)
+    ).as_posix()
+
+    yaml_dump = yaml.safe_dump(datos_front, sort_keys=False, allow_unicode=True).strip()
+
+    contenido = (
+        f"---\n{yaml_dump}\n---\n\n"
+        "import { Aside } from '@astrojs/starlight/components';\n"
+        f"import ContenidoOriginal from '{ruta_relativa}';\n\n"
+        "<Aside type=\"note\">\n"
+        f"  <p>{mensaje}</p>\n"
+        "</Aside>\n\n"
+        "<ContenidoOriginal />\n"
+    )
+    destino.write_text(contenido, encoding='utf-8')
+
+
+def traducir_texto(texto: str, codigo_idioma: str, nombre_idioma: str) -> str:
+    """Intenta traducir un texto con la API pública de Google Translate."""
+    if not texto:
+        return texto
+
+    url = 'https://translate.googleapis.com/translate_a/single'
+    params = {'client': 'gtx', 'sl': 'es', 'tl': codigo_idioma, 'dt': 't', 'q': texto}
+
+    for _ in range(5):
+        try:
+            respuesta = requests.get(url, params=params, timeout=10)
+            respuesta.raise_for_status()
+            datos = respuesta.json()
+            return ''.join(segmento[0] for segmento in datos[0])
+        except (RequestException, ValueError):
+            time.sleep(1)
+
+    print(f"Aviso: no se pudo traducir '{texto}' al idioma {nombre_idioma}. Se conservará el original.")
+    return texto
+
+
+def main() -> None:
+    archivos = [
+        ruta
+        for ruta in BASE_DOCS.rglob('*.mdx')
+        if 'en/' not in ruta.as_posix()
+        and 'id/' not in ruta.as_posix()
+        and 'ja/' not in ruta.as_posix()
+        and ruta.name != 'index.mdx'
+    ]
+
+    for ruta in archivos:
+        front = cargar_frontmatter(ruta)
+        titulo_es = front.get('title', '')
+        descripcion_es = front.get('description')
+
+        for idioma, config in IDIOMAS.items():
+            print(f"Traduciendo {ruta.relative_to(BASE_DOCS)} -> {idioma}")
+            titulo = traducir_texto(titulo_es, config['codigo'], idioma) if titulo_es else ''
+            front_idioma: dict[str, object] = {}
+            if titulo:
+                front_idioma['title'] = titulo
+            if descripcion_es:
+                front_idioma['description'] = traducir_texto(descripcion_es, config['codigo'], idioma)
+
+            crear_archivo_idioma(ruta, idioma, front_idioma, config['mensaje'])
+
+
+if __name__ == '__main__':
+    main()

--- a/src/content/docs/en/control/bucles.mdx
+++ b/src/content/docs/en/control/bucles.mdx
@@ -1,0 +1,13 @@
+---
+title: Loops
+description: Repetitive structures available in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/bucles.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/control/condicionales.mdx
+++ b/src/content/docs/en/control/condicionales.mdx
@@ -1,0 +1,13 @@
+---
+title: Conditional
+description: Use of conditional structures in quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/condicionales.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/control/flujo.mdx
+++ b/src/content/docs/en/control/flujo.mdx
@@ -1,0 +1,13 @@
+---
+title: Flow control
+description: Tools to modify the execution flow in quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/flujo.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/datos/conversion-tipos.mdx
+++ b/src/content/docs/en/datos/conversion-tipos.mdx
@@ -1,0 +1,13 @@
+---
+title: Type conversion
+description: Methods available to convert values ​​into quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/conversion-tipos.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/datos/json.mdx
+++ b/src/content/docs/en/datos/json.mdx
@@ -1,0 +1,13 @@
+---
+title: Json
+description: Manipulation of `JSN` values ​​in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/json.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/datos/listas.mdx
+++ b/src/content/docs/en/datos/listas.mdx
@@ -1,0 +1,13 @@
+---
+title: Lists
+description: Operations with lists in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/listas.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/ejemplos/basicos.mdx
+++ b/src/content/docs/en/ejemplos/basicos.mdx
@@ -1,0 +1,13 @@
+---
+title: Basic examples
+description: Simple fragments to become familiar with Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/basicos.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/ejemplos/mejores-practicas.mdx
+++ b/src/content/docs/en/ejemplos/mejores-practicas.mdx
@@ -1,0 +1,13 @@
+---
+title: Best practices
+description: Recommendations to write code maintainable in quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/mejores-practicas.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/ejemplos/proyectos.mdx
+++ b/src/content/docs/en/ejemplos/proyectos.mdx
@@ -1,0 +1,13 @@
+---
+title: Project ideas
+description: Proposals to practice with Quetzal language using version V0.0.12.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/proyectos.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/errores/excepciones.mdx
+++ b/src/content/docs/en/errores/excepciones.mdx
@@ -1,0 +1,13 @@
+---
+title: Exceptions
+description: MANAGEMENT OF ERRORS IN QUETZAL LANGUAGE.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../errores/excepciones.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/errores/try-catch.mdx
+++ b/src/content/docs/en/errores/try-catch.mdx
@@ -1,0 +1,13 @@
+---
+title: Blocks try/capture
+description: Detailed use of `try`,` capture 'and `finally' in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../errores/try-catch.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/funciones/asincronas.mdx
+++ b/src/content/docs/en/funciones/asincronas.mdx
@@ -1,0 +1,13 @@
+---
+title: Asynchronous functions
+description: Current state of asynchronous support in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/asincronas.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/funciones/definicion.mdx
+++ b/src/content/docs/en/funciones/definicion.mdx
@@ -1,0 +1,13 @@
+---
+title: Definition of functions
+description: Syntax and characteristics of the functions in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/definicion.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/funciones/parametros.mdx
+++ b/src/content/docs/en/funciones/parametros.mdx
@@ -1,0 +1,13 @@
+---
+title: Parameters
+description: How to define and use parameters in Quetzal language functions.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/parametros.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/fundamentos/comentarios.mdx
+++ b/src/content/docs/en/fundamentos/comentarios.mdx
@@ -1,0 +1,14 @@
+---
+title: Comments
+description: Ways of documenting code in quetzal language and recommendations for
+  use.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/comentarios.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/fundamentos/operadores.mdx
+++ b/src/content/docs/en/fundamentos/operadores.mdx
@@ -1,0 +1,13 @@
+---
+title: Operators
+description: Operators available in quetzal language and practical examples of use.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/operadores.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/fundamentos/sintaxis-basica.mdx
+++ b/src/content/docs/en/fundamentos/sintaxis-basica.mdx
@@ -1,0 +1,13 @@
+---
+title: Basic syntax
+description: Essential elements of the Quetzal language syntax in its V0.0.12 version.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/sintaxis-basica.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/fundamentos/tipos-datos.mdx
+++ b/src/content/docs/en/fundamentos/tipos-datos.mdx
@@ -1,0 +1,13 @@
+---
+title: Data types
+description: Types available in quetzal language, conversion methods and common operations.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/tipos-datos.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/fundamentos/variables-constantes.mdx
+++ b/src/content/docs/en/fundamentos/variables-constantes.mdx
@@ -1,0 +1,13 @@
+---
+title: Variables and constant
+description: Declaration, mutability and scope of the variables in quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/variables-constantes.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/index.mdx
+++ b/src/content/docs/en/index.mdx
@@ -1,0 +1,66 @@
+---
+title: Quetzal Language
+description: Official documentation for the Quetzal Programming Language v0.0.2
+template: splash
+head:
+  - tag: meta
+    attrs:
+      property: 'og:title'
+      content: 'Quetzal Language - Official Documentation'
+  - tag: meta
+    attrs:
+      property: 'og:description'
+      content: 'Documentation for the Quetzal Language v0.0.2 with guides, examples, and references in Spanish'
+  - tag: meta
+    attrs:
+      property: 'og:image'
+      content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
+  - tag: meta
+    attrs:
+      property: 'og:url'
+      content: 'https://lenguaje-quetzal.antaresgt.com/en/'
+  - tag: meta
+    attrs:
+      property: 'og:type'
+      content: 'website'
+  - tag: meta
+    attrs:
+      name: 'twitter:card'
+      content: 'summary_large_image'
+  - tag: meta
+    attrs:
+      name: 'twitter:title'
+      content: 'Quetzal Language - Official Documentation'
+  - tag: meta
+    attrs:
+      name: 'twitter:description'
+      content: 'Documentation for the Quetzal Language v0.0.2 with guides, examples, and references in Spanish'
+  - tag: meta
+    attrs:
+      name: 'twitter:image'
+      content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
+hero:
+  tagline: A modern programming language with Spanish syntax
+  image:
+    alt: Quetzal Language logo
+    light: ../../../assets/logo_lenguaje_quetzal.png
+    dark: ../../../assets/logo_lenguaje_quetzal_blanc.png
+  actions:
+    - text: Start tour
+      link: /en/introduccion/bienvenido/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub repository
+      link: https://github.com/AntaresGT/lenguaje-quetzal
+      icon: external
+      variant: secondary
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../index.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/introduccion/bienvenido.mdx
+++ b/src/content/docs/en/introduccion/bienvenido.mdx
@@ -1,0 +1,14 @@
+---
+title: Welcome to Quetzal Language
+description: General Introduction to Quetzal Language V0.0.12, its main goals and
+  characteristics.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/bienvenido.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/introduccion/hoja-de-ruta.mdx
+++ b/src/content/docs/en/introduccion/hoja-de-ruta.mdx
@@ -1,0 +1,14 @@
+---
+title: Roadmap
+description: Discover the Quetzal Language Route Map, from its beginnings to the future.
+  Learn about its evolution, key features and how you can contribute.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/hoja-de-ruta.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/introduccion/instalacion.mdx
+++ b/src/content/docs/en/introduccion/instalacion.mdx
@@ -1,0 +1,13 @@
+---
+title: QUETZAL LANGUAGE INSTALLATION
+description: Step by step guide to install the Quetzal language interpreter in Windows.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/instalacion.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/introduccion/primer-programa.mdx
+++ b/src/content/docs/en/introduccion/primer-programa.mdx
@@ -1,0 +1,14 @@
+---
+title: Your first program in Quetzal
+description: Step by step tutorial to create and execute your first complete program
+  in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/primer-programa.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/io/archivos.mdx
+++ b/src/content/docs/en/io/archivos.mdx
@@ -1,0 +1,13 @@
+---
+title: File management
+description: Status of access to files and configuration by `` `` `json`.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../io/archivos.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/io/consola.mdx
+++ b/src/content/docs/en/io/consola.mdx
@@ -1,0 +1,13 @@
+---
+title: Console
+description: Input and output operations available through `console`.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../io/consola.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/modulos/importar-exportar.mdx
+++ b/src/content/docs/en/modulos/importar-exportar.mdx
@@ -1,0 +1,13 @@
+---
+title: Import and export
+description: Share code between files in quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../modulos/importar-exportar.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/modulos/organizacion.mdx
+++ b/src/content/docs/en/modulos/organizacion.mdx
@@ -1,0 +1,13 @@
+---
+title: Organization of modules
+description: How to structure Quetzal language projects with multiple files.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../modulos/organizacion.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/oop/clases-objetos.mdx
+++ b/src/content/docs/en/oop/clases-objetos.mdx
@@ -1,0 +1,13 @@
+---
+title: Objects
+description: Definition and use of objects in quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/clases-objetos.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/oop/constructores.mdx
+++ b/src/content/docs/en/oop/constructores.mdx
@@ -1,0 +1,13 @@
+---
+title: Builders
+description: How to initiate objects in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/constructores.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/oop/modificadores-acceso.mdx
+++ b/src/content/docs/en/oop/modificadores-acceso.mdx
@@ -1,0 +1,13 @@
+---
+title: Access modifiers
+description: Visibility control in Quetzal language objects.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/modificadores-acceso.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/referencia/funciones-integradas.mdx
+++ b/src/content/docs/en/referencia/funciones-integradas.mdx
@@ -1,0 +1,13 @@
+---
+title: Integrated functions
+description: Functions provided by the Quetzal Language Interpreter.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/funciones-integradas.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/referencia/gramatica.mdx
+++ b/src/content/docs/en/referencia/gramatica.mdx
@@ -1,0 +1,13 @@
+---
+title: Grammar
+description: Overview of Quetzal language grammar.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/gramatica.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/en/referencia/palabras-reservadas.mdx
+++ b/src/content/docs/en/referencia/palabras-reservadas.mdx
@@ -1,0 +1,13 @@
+---
+title: Reserved words
+description: List of words that cannot be used as identifiers in Quetzal language.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/palabras-reservadas.mdx';
+
+<Aside type="note">
+  <p>Translation in progress. The following content is temporarily shown in Spanish.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/control/bucles.mdx
+++ b/src/content/docs/id/control/bucles.mdx
@@ -1,0 +1,13 @@
+---
+title: Loop
+description: Struktur berulang tersedia dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/bucles.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/control/condicionales.mdx
+++ b/src/content/docs/id/control/condicionales.mdx
@@ -1,0 +1,13 @@
+---
+title: Bersyarat
+description: Penggunaan struktur bersyarat dalam bahasa quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/condicionales.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/control/flujo.mdx
+++ b/src/content/docs/id/control/flujo.mdx
@@ -1,0 +1,13 @@
+---
+title: Kontrol aliran
+description: Alat untuk memodifikasi aliran eksekusi dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/flujo.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/datos/conversion-tipos.mdx
+++ b/src/content/docs/id/datos/conversion-tipos.mdx
@@ -1,0 +1,13 @@
+---
+title: Ketik konversi
+description: Metode yang tersedia untuk mengubah nilai menjadi bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/conversion-tipos.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/datos/json.mdx
+++ b/src/content/docs/id/datos/json.mdx
@@ -1,0 +1,13 @@
+---
+title: Json
+description: Manipulasi nilai `jsn` dalam bahasa quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/json.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/datos/listas.mdx
+++ b/src/content/docs/id/datos/listas.mdx
@@ -1,0 +1,13 @@
+---
+title: Daftar
+description: Operasi dengan daftar dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/listas.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/ejemplos/basicos.mdx
+++ b/src/content/docs/id/ejemplos/basicos.mdx
@@ -1,0 +1,13 @@
+---
+title: Contoh dasar
+description: Fragmen sederhana untuk menjadi terbiasa dengan bahasa quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/basicos.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/ejemplos/mejores-practicas.mdx
+++ b/src/content/docs/id/ejemplos/mejores-practicas.mdx
@@ -1,0 +1,14 @@
+---
+title: Praktik terbaik
+description: Rekomendasi untuk menulis kode yang dapat dipertahankan dalam bahasa
+  Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/mejores-practicas.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/ejemplos/proyectos.mdx
+++ b/src/content/docs/id/ejemplos/proyectos.mdx
@@ -1,0 +1,13 @@
+---
+title: Ide Proyek
+description: Proposal untuk berlatih dengan bahasa quetzal menggunakan versi v0.0.12.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/proyectos.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/errores/excepciones.mdx
+++ b/src/content/docs/id/errores/excepciones.mdx
@@ -1,0 +1,13 @@
+---
+title: Pengecualian
+description: Manajemen Kesalahan dalam Bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../errores/excepciones.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/errores/try-catch.mdx
+++ b/src/content/docs/id/errores/try-catch.mdx
@@ -1,0 +1,13 @@
+---
+title: Blok mencoba/menangkap
+description: Penggunaan rinci `try`,` capture 'dan `akhirnya' dalam bahasa quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../errores/try-catch.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/funciones/asincronas.mdx
+++ b/src/content/docs/id/funciones/asincronas.mdx
@@ -1,0 +1,13 @@
+---
+title: Fungsi asinkron
+description: Keadaan dukungan asinkron saat ini dalam bahasa quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/asincronas.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/funciones/definicion.mdx
+++ b/src/content/docs/id/funciones/definicion.mdx
@@ -1,0 +1,13 @@
+---
+title: Definisi fungsi
+description: Sintaks dan karakteristik fungsi dalam bahasa quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/definicion.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/funciones/parametros.mdx
+++ b/src/content/docs/id/funciones/parametros.mdx
@@ -1,0 +1,13 @@
+---
+title: Parameter
+description: Cara mendefinisikan dan menggunakan parameter dalam fungsi bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/parametros.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/fundamentos/comentarios.mdx
+++ b/src/content/docs/id/fundamentos/comentarios.mdx
@@ -1,0 +1,14 @@
+---
+title: Komentar
+description: Cara mendokumentasikan kode dalam bahasa Quetzal dan rekomendasi untuk
+  digunakan.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/comentarios.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/fundamentos/operadores.mdx
+++ b/src/content/docs/id/fundamentos/operadores.mdx
@@ -1,0 +1,13 @@
+---
+title: Operator
+description: Operator tersedia dalam bahasa Quetzal dan contoh penggunaan praktis.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/operadores.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/fundamentos/sintaxis-basica.mdx
+++ b/src/content/docs/id/fundamentos/sintaxis-basica.mdx
@@ -1,0 +1,14 @@
+---
+title: Sintaks dasar
+description: Elemen -elemen penting dari sintaksis bahasa quetzal dalam versi v0.0.12
+  -nya.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/sintaxis-basica.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/fundamentos/tipos-datos.mdx
+++ b/src/content/docs/id/fundamentos/tipos-datos.mdx
@@ -1,0 +1,14 @@
+---
+title: Tipe data
+description: Jenis yang tersedia dalam bahasa Quetzal, metode konversi dan operasi
+  umum.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/tipos-datos.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/fundamentos/variables-constantes.mdx
+++ b/src/content/docs/id/fundamentos/variables-constantes.mdx
@@ -1,0 +1,13 @@
+---
+title: Variabel dan konstan
+description: Deklarasi, Mutabilitas dan Lingkup Variabel dalam Bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/variables-constantes.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/index.mdx
+++ b/src/content/docs/id/index.mdx
@@ -1,0 +1,66 @@
+---
+title: Bahasa Quetzal
+description: Dokumentasi resmi Bahasa Pemrograman Quetzal v0.0.2
+template: splash
+head:
+  - tag: meta
+    attrs:
+      property: 'og:title'
+      content: 'Bahasa Quetzal - Dokumentasi Resmi'
+  - tag: meta
+    attrs:
+      property: 'og:description'
+      content: 'Dokumentasi Bahasa Quetzal v0.0.2 dengan panduan, contoh, dan referensi dalam bahasa Spanyol'
+  - tag: meta
+    attrs:
+      property: 'og:image'
+      content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
+  - tag: meta
+    attrs:
+      property: 'og:url'
+      content: 'https://lenguaje-quetzal.antaresgt.com/id/'
+  - tag: meta
+    attrs:
+      property: 'og:type'
+      content: 'website'
+  - tag: meta
+    attrs:
+      name: 'twitter:card'
+      content: 'summary_large_image'
+  - tag: meta
+    attrs:
+      name: 'twitter:title'
+      content: 'Bahasa Quetzal - Dokumentasi Resmi'
+  - tag: meta
+    attrs:
+      name: 'twitter:description'
+      content: 'Dokumentasi Bahasa Quetzal v0.0.2 dengan panduan, contoh, dan referensi dalam bahasa Spanyol'
+  - tag: meta
+    attrs:
+      name: 'twitter:image'
+      content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
+hero:
+  tagline: Bahasa pemrograman modern dengan sintaks dalam bahasa Spanyol
+  image:
+    alt: Logo Bahasa Quetzal
+    light: ../../../assets/logo_lenguaje_quetzal.png
+    dark: ../../../assets/logo_lenguaje_quetzal_blanc.png
+  actions:
+    - text: Mulai tur
+      link: /id/introduccion/bienvenido/
+      icon: right-arrow
+      variant: primary
+    - text: Repositori di GitHub
+      link: https://github.com/AntaresGT/lenguaje-quetzal
+      icon: external
+      variant: secondary
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../index.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/introduccion/bienvenido.mdx
+++ b/src/content/docs/id/introduccion/bienvenido.mdx
@@ -1,0 +1,14 @@
+---
+title: Selamat datang di bahasa Quetzal
+description: Pengantar Umum untuk Bahasa Quetzal V0.0.12, tujuan dan karakteristik
+  utamanya.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/bienvenido.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/introduccion/hoja-de-ruta.mdx
+++ b/src/content/docs/id/introduccion/hoja-de-ruta.mdx
@@ -1,0 +1,14 @@
+---
+title: Peta jalan
+description: Temukan peta rute bahasa Quetzal, dari awal hingga masa depan. Pelajari
+  tentang evolusinya, fitur utama dan bagaimana Anda dapat berkontribusi.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/hoja-de-ruta.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/introduccion/instalacion.mdx
+++ b/src/content/docs/id/introduccion/instalacion.mdx
@@ -1,0 +1,14 @@
+---
+title: Instalasi Bahasa Quetzal
+description: Panduan langkah demi langkah untuk menginstal interpreter bahasa Quetzal
+  di Windows.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/instalacion.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/introduccion/primer-programa.mdx
+++ b/src/content/docs/id/introduccion/primer-programa.mdx
@@ -1,0 +1,14 @@
+---
+title: Program pertama Anda di Quetzal
+description: Tutorial langkah demi langkah untuk membuat dan menjalankan program lengkap
+  pertama Anda dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/primer-programa.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/io/archivos.mdx
+++ b/src/content/docs/id/io/archivos.mdx
@@ -1,0 +1,13 @@
+---
+title: Manajemen file
+description: Status akses ke file dan konfigurasi dengan `` `` json`.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../io/archivos.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/io/consola.mdx
+++ b/src/content/docs/id/io/consola.mdx
@@ -1,0 +1,13 @@
+---
+title: Menghibur
+description: Operasi input dan output tersedia melalui `konsol`.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../io/consola.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/modulos/importar-exportar.mdx
+++ b/src/content/docs/id/modulos/importar-exportar.mdx
@@ -1,0 +1,13 @@
+---
+title: Impor dan Ekspor
+description: Bagikan kode antar file dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../modulos/importar-exportar.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/modulos/organizacion.mdx
+++ b/src/content/docs/id/modulos/organizacion.mdx
@@ -1,0 +1,13 @@
+---
+title: Organisasi Modul
+description: Cara menyusun proyek bahasa Quetzal dengan banyak file.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../modulos/organizacion.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/oop/clases-objetos.mdx
+++ b/src/content/docs/id/oop/clases-objetos.mdx
@@ -1,0 +1,13 @@
+---
+title: Objek
+description: Definisi dan Penggunaan Objek dalam Bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/clases-objetos.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/oop/constructores.mdx
+++ b/src/content/docs/id/oop/constructores.mdx
@@ -1,0 +1,13 @@
+---
+title: Pembangun
+description: Cara memulai objek dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/constructores.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/oop/modificadores-acceso.mdx
+++ b/src/content/docs/id/oop/modificadores-acceso.mdx
@@ -1,0 +1,13 @@
+---
+title: Pengubah akses
+description: Kontrol visibilitas dalam objek bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/modificadores-acceso.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/referencia/funciones-integradas.mdx
+++ b/src/content/docs/id/referencia/funciones-integradas.mdx
@@ -1,0 +1,13 @@
+---
+title: Fungsi terintegrasi
+description: Fungsi yang disediakan oleh penerjemah bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/funciones-integradas.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/referencia/gramatica.mdx
+++ b/src/content/docs/id/referencia/gramatica.mdx
@@ -1,0 +1,13 @@
+---
+title: Tata bahasa
+description: Tinjauan Tata Bahasa Bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/gramatica.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/id/referencia/palabras-reservadas.mdx
+++ b/src/content/docs/id/referencia/palabras-reservadas.mdx
@@ -1,0 +1,14 @@
+---
+title: Kata -kata yang dipesan
+description: Daftar kata -kata yang tidak dapat digunakan sebagai pengidentifikasi
+  dalam bahasa Quetzal.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/palabras-reservadas.mdx';
+
+<Aside type="note">
+  <p>Terjemahan sedang dalam proses. Konten berikut ditampilkan sementara dalam bahasa Spanyol.</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/control/bucles.mdx
+++ b/src/content/docs/ja/control/bucles.mdx
@@ -1,0 +1,13 @@
+---
+title: ループ
+description: Quetzal言語で利用可能な反復構造。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/bucles.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/control/condicionales.mdx
+++ b/src/content/docs/ja/control/condicionales.mdx
@@ -1,0 +1,13 @@
+---
+title: 条件付き
+description: Quetzal言語での条件構造の使用。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/condicionales.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/control/flujo.mdx
+++ b/src/content/docs/ja/control/flujo.mdx
@@ -1,0 +1,13 @@
+---
+title: フロー制御
+description: Quetzal言語で実行フローを変更するためのツール。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../control/flujo.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/datos/conversion-tipos.mdx
+++ b/src/content/docs/ja/datos/conversion-tipos.mdx
@@ -1,0 +1,13 @@
+---
+title: タイプ変換
+description: 値をQuetzal言語に変換する方法。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/conversion-tipos.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/datos/json.mdx
+++ b/src/content/docs/ja/datos/json.mdx
@@ -1,0 +1,13 @@
+---
+title: JSON
+description: Quetzal言語での「JSN」値の操作。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/json.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/datos/listas.mdx
+++ b/src/content/docs/ja/datos/listas.mdx
@@ -1,0 +1,13 @@
+---
+title: リスト
+description: Quetzal言語のリストを備えた操作。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../datos/listas.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/ejemplos/basicos.mdx
+++ b/src/content/docs/ja/ejemplos/basicos.mdx
@@ -1,0 +1,13 @@
+---
+title: 基本的な例
+description: Quetzal言語に精通する単純な断片。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/basicos.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/ejemplos/mejores-practicas.mdx
+++ b/src/content/docs/ja/ejemplos/mejores-practicas.mdx
@@ -1,0 +1,13 @@
+---
+title: ベストプラクティス
+description: Quetzal言語で維持可能なコードを作成するための推奨事項。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/mejores-practicas.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/ejemplos/proyectos.mdx
+++ b/src/content/docs/ja/ejemplos/proyectos.mdx
@@ -1,0 +1,13 @@
+---
+title: プロジェクトのアイデア
+description: バージョンv0.0.12を使用して、Quetzal言語で練習する提案。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../ejemplos/proyectos.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/errores/excepciones.mdx
+++ b/src/content/docs/ja/errores/excepciones.mdx
@@ -1,0 +1,13 @@
+---
+title: 例外
+description: Quetzal言語のエラーの管理。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../errores/excepciones.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/errores/try-catch.mdx
+++ b/src/content/docs/ja/errores/try-catch.mdx
@@ -1,0 +1,13 @@
+---
+title: ブロック試行/キャプチャ
+description: Quetzal言語での「Try」、「Capture」、および「Capture」、および「Capture」の詳細な使用。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../errores/try-catch.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/funciones/asincronas.mdx
+++ b/src/content/docs/ja/funciones/asincronas.mdx
@@ -1,0 +1,13 @@
+---
+title: 非同期関数
+description: Quetzal言語における非同期サポートの現在の状態。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/asincronas.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/funciones/definicion.mdx
+++ b/src/content/docs/ja/funciones/definicion.mdx
@@ -1,0 +1,13 @@
+---
+title: 関数の定義
+description: Quetzal言語の関数の構文と特性。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/definicion.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/funciones/parametros.mdx
+++ b/src/content/docs/ja/funciones/parametros.mdx
@@ -1,0 +1,13 @@
+---
+title: パラメーター
+description: Quetzal言語関数でパラメーターを定義および使用する方法。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../funciones/parametros.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/fundamentos/comentarios.mdx
+++ b/src/content/docs/ja/fundamentos/comentarios.mdx
@@ -1,0 +1,13 @@
+---
+title: コメント
+description: Quetzal言語でコードを文書化する方法と使用のための推奨事項。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/comentarios.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/fundamentos/operadores.mdx
+++ b/src/content/docs/ja/fundamentos/operadores.mdx
@@ -1,0 +1,13 @@
+---
+title: オペレーター
+description: Quetzal言語と使用の実用的な例で利用可能なオペレーター。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/operadores.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/fundamentos/sintaxis-basica.mdx
+++ b/src/content/docs/ja/fundamentos/sintaxis-basica.mdx
@@ -1,0 +1,13 @@
+---
+title: 基本的な構文
+description: V0.0.12バージョンのQuetzal言語構文の重要な要素。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/sintaxis-basica.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/fundamentos/tipos-datos.mdx
+++ b/src/content/docs/ja/fundamentos/tipos-datos.mdx
@@ -1,0 +1,13 @@
+---
+title: データ型
+description: Quetzal言語、変換方法、共通操作で利用可能なタイプ。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/tipos-datos.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/fundamentos/variables-constantes.mdx
+++ b/src/content/docs/ja/fundamentos/variables-constantes.mdx
@@ -1,0 +1,13 @@
+---
+title: 変数と定数
+description: Quetzal言語の変数の宣言、可変性、範囲。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../fundamentos/variables-constantes.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/index.mdx
+++ b/src/content/docs/ja/index.mdx
@@ -1,0 +1,66 @@
+---
+title: ケツァル語
+description: ケツァルプログラミング言語 v0.0.2 の公式ドキュメント
+template: splash
+head:
+  - tag: meta
+    attrs:
+      property: 'og:title'
+      content: 'ケツァル語 - 公式ドキュメント'
+  - tag: meta
+    attrs:
+      property: 'og:description'
+      content: 'ケツァル言語 v0.0.2 のドキュメント。ガイド、サンプル、リファレンスをスペイン語で提供'
+  - tag: meta
+    attrs:
+      property: 'og:image'
+      content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
+  - tag: meta
+    attrs:
+      property: 'og:url'
+      content: 'https://lenguaje-quetzal.antaresgt.com/ja/'
+  - tag: meta
+    attrs:
+      property: 'og:type'
+      content: 'website'
+  - tag: meta
+    attrs:
+      name: 'twitter:card'
+      content: 'summary_large_image'
+  - tag: meta
+    attrs:
+      name: 'twitter:title'
+      content: 'ケツァル語 - 公式ドキュメント'
+  - tag: meta
+    attrs:
+      name: 'twitter:description'
+      content: 'ケツァル言語 v0.0.2 のドキュメント。ガイド、サンプル、リファレンスをスペイン語で提供'
+  - tag: meta
+    attrs:
+      name: 'twitter:image'
+      content: 'https://github.com/AntaresGT/lenguaje-quetzal/raw/main/imagenes/logo_lenguaje_quetzal.png'
+hero:
+  tagline: スペイン語の構文を備えたモダンなプログラミング言語
+  image:
+    alt: ケツァル語のロゴ
+    light: ../../../assets/logo_lenguaje_quetzal.png
+    dark: ../../../assets/logo_lenguaje_quetzal_blanc.png
+  actions:
+    - text: ガイドを開始
+      link: /ja/introduccion/bienvenido/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub リポジトリ
+      link: https://github.com/AntaresGT/lenguaje-quetzal
+      icon: external
+      variant: secondary
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../index.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/introduccion/bienvenido.mdx
+++ b/src/content/docs/ja/introduccion/bienvenido.mdx
@@ -1,0 +1,13 @@
+---
+title: Quetzal言語へようこそ
+description: Quetzal Language V0.0.12の一般的な紹介、その主な目標と特性。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/bienvenido.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/introduccion/hoja-de-ruta.mdx
+++ b/src/content/docs/ja/introduccion/hoja-de-ruta.mdx
@@ -1,0 +1,13 @@
+---
+title: ロードマップ
+description: その始まりから未来まで、Quetzal言語ルートマップを発見してください。その進化、重要な機能、貢献方法について学びます。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/hoja-de-ruta.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/introduccion/instalacion.mdx
+++ b/src/content/docs/ja/introduccion/instalacion.mdx
@@ -1,0 +1,13 @@
+---
+title: Quetzal言語のインストール
+description: ステップバイステップガイドWindowsにQuetzal言語インタープリターをインストールします。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/instalacion.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/introduccion/primer-programa.mdx
+++ b/src/content/docs/ja/introduccion/primer-programa.mdx
@@ -1,0 +1,13 @@
+---
+title: ケツァルでの最初のプログラム
+description: Quetzal言語で最初の完全なプログラムを作成および実行するためのステップバイステップチュートリアル。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../introduccion/primer-programa.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/io/archivos.mdx
+++ b/src/content/docs/ja/io/archivos.mdx
@@ -1,0 +1,13 @@
+---
+title: ファイル管理
+description: 「Json」によるファイルへのアクセスと構成のステータス。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../io/archivos.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/io/consola.mdx
+++ b/src/content/docs/ja/io/consola.mdx
@@ -1,0 +1,13 @@
+---
+title: コンソール
+description: 「コンソール」から利用可能な入力および出力操作。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../io/consola.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/modulos/importar-exportar.mdx
+++ b/src/content/docs/ja/modulos/importar-exportar.mdx
@@ -1,0 +1,13 @@
+---
+title: インポートとエクスポート
+description: Quetzal言語でファイル間でコードを共有します。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../modulos/importar-exportar.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/modulos/organizacion.mdx
+++ b/src/content/docs/ja/modulos/organizacion.mdx
@@ -1,0 +1,13 @@
+---
+title: モジュールの構成
+description: 複数のファイルを使用してQuetzal言語プロジェクトを構築する方法。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../modulos/organizacion.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/oop/clases-objetos.mdx
+++ b/src/content/docs/ja/oop/clases-objetos.mdx
@@ -1,0 +1,13 @@
+---
+title: オブジェクト
+description: Quetzal言語でのオブジェクトの定義と使用。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/clases-objetos.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/oop/constructores.mdx
+++ b/src/content/docs/ja/oop/constructores.mdx
@@ -1,0 +1,13 @@
+---
+title: ビルダー
+description: Quetzal言語でオブジェクトを開始する方法。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/constructores.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/oop/modificadores-acceso.mdx
+++ b/src/content/docs/ja/oop/modificadores-acceso.mdx
@@ -1,0 +1,13 @@
+---
+title: アクセス修飾子
+description: Quetzal言語オブジェクトの視認性制御。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../oop/modificadores-acceso.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/referencia/funciones-integradas.mdx
+++ b/src/content/docs/ja/referencia/funciones-integradas.mdx
@@ -1,0 +1,13 @@
+---
+title: 統合関数
+description: Quetzal言語通訳によって提供される関数。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/funciones-integradas.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/referencia/gramatica.mdx
+++ b/src/content/docs/ja/referencia/gramatica.mdx
@@ -1,0 +1,13 @@
+---
+title: 文法
+description: Quetzal言語文法の概要。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/gramatica.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />

--- a/src/content/docs/ja/referencia/palabras-reservadas.mdx
+++ b/src/content/docs/ja/referencia/palabras-reservadas.mdx
@@ -1,0 +1,13 @@
+---
+title: 予約された言葉
+description: Quetzal言語の識別子として使用できない単語のリスト。
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ContenidoOriginal from '../../referencia/palabras-reservadas.mdx';
+
+<Aside type="note">
+  <p>翻訳は進行中です。完成までの間、以下のコンテンツはスペイン語版を表示しています。</p>
+</Aside>
+
+<ContenidoOriginal />


### PR DESCRIPTION
## Resumen
- generar script para crear versiones locales de la documentación reutilizando el contenido en español
- añadir la estructura de contenidos para inglés, indonesio y japonés con metadatos traducidos y aviso de traducción pendiente
- incorporar páginas principales indexadas por idioma con enlaces actualizados

## Pruebas
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d4bb2f20a8832fb2f49fdfe9378a04